### PR TITLE
fix accuracy metric for nested lists of diff lengths

### DIFF
--- a/farm/metrics.py
+++ b/farm/metrics.py
@@ -8,10 +8,24 @@ from sklearn.metrics import matthews_corrcoef, f1_score
 def simple_accuracy(preds, labels):
     # TODO: THIS HACKY TRY CATCH IS FOR GNAD
     try:
+        # nested lists with different lengths
+        if type(preds[0]) == list:
+            preds_lengths = [len(e) for e in preds]
+            label_lengths = [len(e) for e in labels]
+            assert preds_lengths == label_lengths
+            if len(set(preds_lengths)) != 1:
+                # pad them to max length
+                max_len = max(preds_lengths)
+                preds = [e + (["[PAD]"] * (max_len - len(e))) for e in preds]
+                labels = [e + (["[PAD]"] * (max_len - len(e))) for e in labels]
+
+        # regular ndarray compatible formats
         preds = np.array(preds)
         labels = np.array(labels)
-        correct = preds == labels
-        return {"acc": correct.mean()}
+        num_pads = (labels == "[PAD]").astype(int).sum()
+        correct = (preds == labels).astype(int)
+        acc = (correct.sum() - num_pads) / (correct.size - num_pads)
+        return {"acc": acc}
     except TypeError:
         return {"acc": (preds == labels.numpy()).mean()}
 

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -4,6 +4,7 @@ import random
 import numpy as np
 import torch
 import mlflow
+from copy import deepcopy
 
 logger = logging.getLogger(__name__)
 
@@ -161,3 +162,22 @@ def convert_iob_to_simple_tags(preds, spans):
         simple_tags.append(cur_tag)
         open_tag = False
     return simple_tags, merged_spans
+
+
+def flatten_list(nested_list):
+    """Flatten an arbitrarily nested list, without recursion (to avoid
+    stack overflows). Returns a new list, the original list is unchanged.
+    >> list(flatten_list([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]]))
+    [1, 2, 3, 4, 5]
+    >> list(flatten_list([[1, 2], 3]))
+    [1, 2, 3]
+    """
+    nested_list = deepcopy(nested_list)
+
+    while nested_list:
+        sublist = nested_list.pop(0)
+
+        if isinstance(sublist, list):
+            nested_list = sublist + nested_list
+        else:
+            yield sublist


### PR DESCRIPTION
This adresses issue https://github.com/deepset-ai/FARM/issues/30

The suggested fix is to pad the lists to equal length before converting to a numpy array and then ignoring the PAD elements in the calculation of the metric. 
