### PR TITLE
Fix use of list in batch_size config param (#38)

### DIFF
--- a/farm/experiment.py
+++ b/farm/experiment.py
@@ -48,7 +48,7 @@ def run_experiment(args):
         use_cuda=args.cuda, local_rank=args.local_rank, fp16=args.fp16
     )
 
-    args.batch_size = args.batch_size // args.gradient_accumulation_steps
+    args.batch_size = int(args.batch_size // args.gradient_accumulation_steps)
     if n_gpu > 1:
         args.batch_size = args.batch_size * n_gpu
     set_all_seeds(args.seed)


### PR DESCRIPTION
The lists in configs gets converted to numpy arrays. The batch_size argument is now type casted to the Python `int` type.