### PR TITLE
fix(lm_finetuning): add sample data to run example script

### DIFF
--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -32,7 +32,7 @@ device, n_gpu = initialize_device_settings(use_cuda=True)
 n_epochs = 1
 batch_size = 32
 evaluate_every = 30
-lang_model = "bert-base-german-cased"
+lang_model = "bert-base-cased"
 
 # 1.Create a tokenizer
 tokenizer = BertTokenizer.from_pretrained(
@@ -41,7 +41,7 @@ tokenizer = BertTokenizer.from_pretrained(
 
 # 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
 processor = BertStyleLMProcessor(
-    data_dir="../data/finetune_sample", tokenizer=tokenizer, max_seq_len=128
+    data_dir="../data/lm_finetune_nips", tokenizer=tokenizer, max_seq_len=128
 )
 # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
 data_silo = DataSilo(processor=processor, batch_size=32)
@@ -86,6 +86,6 @@ trainer = Trainer(
 model = trainer.train(model)
 
 # 8. Hooray! You have a model. Store it:
-save_dir = "saved_models/bert-german-lm-tutorial"
+save_dir = "saved_models/bert-english-lm-tutorial"
 model.save(save_dir)
 processor.save(save_dir)

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -31,6 +31,7 @@ from farm.data_handler.input_features import (
 from farm.data_handler.dataset import convert_features_to_dataset
 from farm.utils import MLFlowLogger as MlLogger
 
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -202,7 +203,7 @@ class Processor(ABC):
                 sample.id = f"{basket.id}-{num}"
 
     def _featurize_samples(self):
-        for basket in self.baskets:
+        for basket in tqdm(self.baskets):
             for sample in basket.samples:
                 sample.features = self._sample_to_features(sample=sample)
 
@@ -635,8 +636,8 @@ class BertStyleLMProcessor(Processor):
         max_seq_len,
         data_dir,
         train_filename="train.txt",
-        dev_filename="dev.txt",
-        test_filename="test.txt",
+        dev_filename=None,
+        test_filename=None,
         dev_split=0.0,
     ):
         # General Processor attributes

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -636,8 +636,8 @@ class BertStyleLMProcessor(Processor):
         max_seq_len,
         data_dir,
         train_filename="train.txt",
-        dev_filename=None,
-        test_filename=None,
+        dev_filename="dev.txt",
+        test_filename="test.txt",
         dev_split=0.0,
     ):
         # General Processor attributes

--- a/farm/data_handler/samples.py
+++ b/farm/data_handler/samples.py
@@ -1,6 +1,8 @@
 from farm.data_handler.utils import get_sentence_pair
 from pytorch_transformers.tokenization_bert import whitespace_tokenize
 from farm.visual.ascii.images import SAMPLE
+from tqdm import tqdm
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -121,7 +123,7 @@ def create_samples_sentence_pairs(baskets):
     """Creates examples for Language Model Finetuning that consist of two sentences and the isNext label indicating if
      the two are subsequent sentences from one doc"""
     all_docs = [b.raw["doc"] for b in baskets]
-    for basket in baskets:
+    for basket in tqdm(baskets):
         doc = basket.raw["doc"]
         basket.samples = []
         for idx in range(len(doc) - 1):


### PR DESCRIPTION
Adding some data to let people run the example script for LM finetuning. 
I took the fulltext from public NIPS papers: https://www.kaggle.com/benhamner/nips-papers

Preprocessed as usual with sentence segmentation and some cleaning for special chars + very short sentences. 