### PR TITLE
Fix lr schedule

### DIFF
--- a/examples/doc_classification.py
+++ b/examples/doc_classification.py
@@ -3,7 +3,7 @@ import logging
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import GermEval18CoarseProcessor
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 from farm.infer import Inferencer
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import Bert
@@ -63,9 +63,8 @@ optimizer, warmup_linear = initialize_optimizer(
     model=model,
     learning_rate=2e-5,
     warmup_proportion=0.1,
-    n_examples=data_silo.n_samples("train"),
-    batch_size=batch_size,
-    n_epochs=1)
+    n_batches=len(data_silo.loaders["train"]),
+    n_epochs=n_epochs)
 
 # 6. Feed everything to the Trainer, which keeps care of growing our model into powerful plant and evaluates it from time to time
 trainer = Trainer(

--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -9,7 +9,7 @@ from farm.modeling.language_model import Bert
 from farm.modeling.prediction_head import BertLMHead, NextSentenceHead
 from farm.modeling.tokenization import BertTokenizer
 from farm.train import Trainer
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 
 from farm.utils import set_all_seeds, MLFlowLogger, initialize_device_settings
 
@@ -44,7 +44,7 @@ processor = BertStyleLMProcessor(
     data_dir="../data/lm_finetune_nips", tokenizer=tokenizer, max_seq_len=128
 )
 # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
-data_silo = DataSilo(processor=processor, batch_size=32)
+data_silo = DataSilo(processor=processor, batch_size=batch_size)
 
 # 4. Create an AdaptiveModel
 # a) which consists of a pretrained language model as a basis
@@ -66,8 +66,7 @@ optimizer, warmup_linear = initialize_optimizer(
     model=model,
     learning_rate=2e-5,
     warmup_proportion=0.1,
-    n_examples=data_silo.n_samples("train"),
-    batch_size=batch_size,
+    n_batches=len(data_silo.loaders["train"]),
     n_epochs=n_epochs,
 )
 

--- a/examples/ner.py
+++ b/examples/ner.py
@@ -3,7 +3,7 @@ import logging
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import CONLLProcessor
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 from farm.infer import Inferencer
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import Bert
@@ -63,8 +63,7 @@ optimizer, warmup_linear = initialize_optimizer(
     model=model,
     learning_rate=2e-5,
     warmup_proportion=0.1,
-    n_examples=data_silo.n_samples("train"),
-    batch_size=batch_size,
+    n_batches=len(data_silo.loaders["train"]),
     n_epochs=n_epochs,
 )
 

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -4,7 +4,7 @@ import pprint
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import SquadProcessor
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 from farm.infer import Inferencer
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import Bert
@@ -70,8 +70,7 @@ optimizer, warmup_linear = initialize_optimizer(
     model=model,
     learning_rate=1e-5,
     warmup_proportion=0.2,
-    n_examples=data_silo.n_samples("train"),
-    batch_size=batch_size,
+    n_batches=len(data_silo.loaders["train"]),
     n_epochs=n_epochs,
 )
 # 6. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time

--- a/farm/experiment.py
+++ b/farm/experiment.py
@@ -4,7 +4,7 @@ import torch
 from farm.data_handler.data_silo import DataSilo
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import LanguageModel
-from farm.modeling.optimization import BertAdam, WarmupLinearSchedule
+from farm.modeling.optimization import BertAdam, WarmupLinearSchedule, initialize_optimizer
 from farm.modeling.prediction_head import PredictionHead
 from farm.modeling.tokenization import BertTokenizer
 from farm.data_handler.processor import Processor
@@ -91,8 +91,7 @@ def run_experiment(args):
         warmup_proportion=args.warmup_proportion,
         loss_scale=args.loss_scale,
         fp16=args.fp16,
-        n_examples=data_silo.n_samples("train"),
-        batch_size=args.batch_size,
+        n_batches=len(data_silo.loaders["train"]),
         grad_acc_steps=args.gradient_accumulation_steps,
         n_epochs=args.epochs,
     )
@@ -173,91 +172,6 @@ def validate_args(args):
                 args.gradient_accumulation_steps
             )
         )
-
-
-def initialize_optimizer(
-    model,
-    n_examples,
-    batch_size,
-    n_epochs,
-    warmup_proportion=0.1,
-    learning_rate=2e-5,
-    fp16=False,
-    loss_scale=0,
-    grad_acc_steps=1,
-    local_rank=-1,
-):
-    num_train_optimization_steps = calculate_optimization_steps(
-        n_examples, batch_size, grad_acc_steps, n_epochs, local_rank
-    )
-
-    # Log params
-    MlLogger.log_params(
-        {
-            "learning_rate": learning_rate,
-            "warmup_proportion": warmup_proportion,
-            "fp16": fp16,
-            "num_train_optimization_steps": num_train_optimization_steps,
-        }
-    )
-    # Prepare optimizer
-    param_optimizer = list(model.named_parameters())
-    no_decay = ["bias", "LayerNorm.bias", "LayerNorm.weight"]
-    optimizer_grouped_parameters = [
-        {
-            "params": [
-                p for n, p in param_optimizer if not any(nd in n for nd in no_decay)
-            ],
-            "weight_decay": 0.01,
-        },
-        {
-            "params": [
-                p for n, p in param_optimizer if any(nd in n for nd in no_decay)
-            ],
-            "weight_decay": 0.0,
-        },
-    ]
-    if fp16:
-        try:
-            from apex.optimizers import FP16_Optimizer
-            from apex.optimizers import FusedAdam
-        except ImportError:
-            raise ImportError(
-                "Please install apex from https://www.github.com/nvidia/apex to use distributed and fp16 training."
-            )
-
-        optimizer = FusedAdam(
-            optimizer_grouped_parameters,
-            lr=learning_rate,
-            bias_correction=False,
-            max_grad_norm=1.0,
-        )
-        if loss_scale == 0:
-            optimizer = FP16_Optimizer(optimizer, dynamic_loss_scale=True)
-        else:
-            optimizer = FP16_Optimizer(optimizer, static_loss_scale=loss_scale)
-        warmup_linear = WarmupLinearSchedule(
-            warmup=warmup_proportion, t_total=num_train_optimization_steps
-        )
-        return optimizer, warmup_linear
-
-    else:
-        optimizer = BertAdam(
-            optimizer_grouped_parameters,
-            lr=learning_rate,
-            warmup=warmup_proportion,
-            t_total=num_train_optimization_steps,
-        )
-        return optimizer, None
-
-
-def calculate_optimization_steps(
-    n_examples, batch_size, grad_acc_steps, n_epochs, local_rank
-):
-    optimization_steps = int(n_examples / batch_size / grad_acc_steps) * n_epochs
-    if local_rank != -1:
-        optimization_steps = optimization_steps // torch.distributed.get_world_size()
-    return optimization_steps
 
 
 def save_model():

--- a/farm/modeling/optimization.py
+++ b/farm/modeling/optimization.py
@@ -329,6 +329,7 @@ class BertAdam(Optimizer):
                     # Exponential moving average of squared gradient values
                     state["next_v"] = torch.zeros_like(p.data)
 
+                state["step"] += 1
                 next_m, next_v = state["next_m"], state["next_v"]
                 beta1, beta2 = group["b1"], group["b2"]
 
@@ -355,17 +356,99 @@ class BertAdam(Optimizer):
                 lr_scheduled = group["lr"]
                 lr_scheduled *= group["schedule"].get_lr(state["step"])
 
-                # Custom logging functionality
-                # MlLogger.write_metrics({"learning_rate": lr_scheduled}, step=state["step"])
-
                 update_with_lr = lr_scheduled * update
                 p.data.add_(-update_with_lr)
-
-                state["step"] += 1
 
                 # step_size = lr_scheduled * math.sqrt(bias_correction2) / bias_correction1
                 # No bias correction
                 # bias_correction1 = 1 - beta1 ** state['step']
                 # bias_correction2 = 1 - beta2 ** state['step']
-
+        # Custom logging functionality
+        # MlLogger.log_metrics({"learning_rate": lr_scheduled}, step=state["step"])
+        # logger.info(f'step:{state["step"]}, lr:{lr_scheduled}')
         return loss
+
+
+def initialize_optimizer(
+    model,
+    n_batches,
+    n_epochs,
+    warmup_proportion=0.1,
+    learning_rate=2e-5,
+    fp16=False,
+    loss_scale=0,
+    grad_acc_steps=1,
+    local_rank=-1,
+):
+    num_train_optimization_steps = calculate_optimization_steps(
+        n_batches, grad_acc_steps, n_epochs, local_rank
+    )
+
+    # Log params
+    MlLogger.log_params(
+        {
+            "learning_rate": learning_rate,
+            "warmup_proportion": warmup_proportion,
+            "fp16": fp16,
+            "num_train_optimization_steps": num_train_optimization_steps,
+        }
+    )
+    # Prepare optimizer
+    param_optimizer = list(model.named_parameters())
+    no_decay = ["bias", "LayerNorm.bias", "LayerNorm.weight"]
+    optimizer_grouped_parameters = [
+        {
+            "params": [
+                p for n, p in param_optimizer if not any(nd in n for nd in no_decay)
+            ],
+            "weight_decay": 0.01,
+        },
+        {
+            "params": [
+                p for n, p in param_optimizer if any(nd in n for nd in no_decay)
+            ],
+            "weight_decay": 0.0,
+        },
+    ]
+    if fp16:
+        try:
+            from apex.optimizers import FP16_Optimizer
+            from apex.optimizers import FusedAdam
+        except ImportError:
+            raise ImportError(
+                "Please install apex from https://www.github.com/nvidia/apex to use distributed and fp16 training."
+            )
+
+        optimizer = FusedAdam(
+            optimizer_grouped_parameters,
+            lr=learning_rate,
+            bias_correction=False,
+            max_grad_norm=1.0,
+        )
+        if loss_scale == 0:
+            optimizer = FP16_Optimizer(optimizer, dynamic_loss_scale=True)
+        else:
+            optimizer = FP16_Optimizer(optimizer, static_loss_scale=loss_scale)
+        warmup_linear = WarmupLinearSchedule(
+            warmup=warmup_proportion, t_total=num_train_optimization_steps
+        )
+        return optimizer, warmup_linear
+
+    else:
+        optimizer = BertAdam(
+            optimizer_grouped_parameters,
+            lr=learning_rate,
+            warmup=warmup_proportion,
+            t_total=num_train_optimization_steps,
+        )
+        return optimizer, None
+
+
+def calculate_optimization_steps(
+    n_batches, grad_acc_steps, n_epochs, local_rank
+):
+    optimization_steps = int(n_batches / grad_acc_steps) * n_epochs
+    if local_rank != -1:
+        optimization_steps = optimization_steps // torch.distributed.get_world_size()
+    logger.info(f"Number of optimization steps: {optimization_steps}")
+    return optimization_steps

--- a/test/test_doc_classification.py
+++ b/test/test_doc_classification.py
@@ -2,7 +2,7 @@ import logging
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import GermEval18CoarseProcessor
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 from farm.infer import Inferencer
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import Bert
@@ -48,8 +48,7 @@ def test_doc_classification(caplog):
         model=model,
         learning_rate=2e-5,
         warmup_proportion=0.1,
-        n_examples=data_silo.n_samples("train"),
-        batch_size=batch_size,
+        n_batches=len(data_silo.loaders["train"]),
         n_epochs=1)
 
     trainer = Trainer(
@@ -73,5 +72,5 @@ def test_doc_classification(caplog):
     ]
     model = Inferencer.load(save_dir)
     result = model.run_inference(dicts=basic_texts)
-    assert result[0]["predictions"][0]["label"] == "OTHER"
-    assert abs(result[0]["predictions"][0]["probability"] - 0.5358161) <= 0.0001
+    assert result[0]["predictions"][0]["label"] == "OFFENSE"
+    assert abs(result[0]["predictions"][0]["probability"] - 0.5256448) <= 0.0001

--- a/test/test_ner.py
+++ b/test/test_ner.py
@@ -1,7 +1,7 @@
 import pytest
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import GermEval14Processor
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 from farm.infer import Inferencer
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import Bert
@@ -48,8 +48,7 @@ def test_ner(caplog):
         model=model,
         learning_rate=2e-5,
         warmup_proportion=0.1,
-        n_examples=data_silo.n_samples("train"),
-        batch_size=batch_size,
+        n_batches=len(data_silo.loaders["train"]),
         n_epochs=n_epochs,
     )
 

--- a/test/test_question_answering.py
+++ b/test/test_question_answering.py
@@ -4,7 +4,7 @@ import pprint
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import SquadProcessor
-from farm.experiment import initialize_optimizer
+from farm.modeling.optimization import initialize_optimizer
 from farm.infer import Inferencer
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.language_model import Bert
@@ -51,8 +51,7 @@ def test_qa(caplog):
         model=model,
         learning_rate=1e-5,
         warmup_proportion=0.2,
-        n_examples=data_silo.n_samples("train"),
-        batch_size=batch_size,
+        n_batches=len(data_silo.loaders["train"]),
         n_epochs=n_epochs,
     )
     trainer = Trainer(

--- a/tutorials/1_farm_building_blocks.ipynb
+++ b/tutorials/1_farm_building_blocks.ipynb
@@ -56,7 +56,7 @@
     "from farm.modeling.language_model import Bert\n",
     "from farm.modeling.prediction_head import TextClassificationHead\n",
     "from farm.modeling.adaptive_model import AdaptiveModel\n",
-    "from farm.experiment import initialize_optimizer\n",
+    "from farm.modeling.optimization import initialize_optimizer\n",
     "from farm.train import Trainer"
    ]
   },
@@ -421,6 +421,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.5"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As described in issue #46 the number of optimization steps was slightly off causing lr=0 in the first training step and, depending on number of epochs, also in the last few steps. This PR shoud fix this. To simplify debugging and inspection of LR schedule I have also added an optional logging of LR to the optimizer class (set via parameter `log_learning_rate`).

I also moved `initialize_optimizer` from experiment to optimizer. This seems to be a more reasonable home for it, because it's not only used in experiment mode.