### PR TITLE
Add whole word masking

### DIFF
--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -29,8 +29,8 @@ ml_logger.init_experiment(
 ##########################
 set_all_seeds(seed=42)
 device, n_gpu = initialize_device_settings(use_cuda=True)
-n_epochs = 1
-batch_size = 32
+n_epochs = 10
+batch_size = 25
 evaluate_every = 30
 lang_model = "bert-base-cased"
 

--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -28,8 +28,8 @@ ml_logger.init_experiment(
 ########## Settings
 ##########################
 device, n_gpu = initialize_device_settings(use_cuda=True)
-n_epochs = 10
-batch_size = 25
+n_epochs = 1
+batch_size = 32
 evaluate_every = 30
 lang_model = "bert-base-cased"
 

--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -27,7 +27,6 @@ ml_logger.init_experiment(
 ##########################
 ########## Settings
 ##########################
-set_all_seeds(seed=42)
 device, n_gpu = initialize_device_settings(use_cuda=True)
 n_epochs = 10
 batch_size = 25
@@ -77,7 +76,7 @@ trainer = Trainer(
     epochs=n_epochs,
     n_gpu=n_gpu,
     warmup_linear=warmup_linear,
-    evaluate_every=5,
+    evaluate_every=evaluate_every,
     device=device,
 )
 

--- a/farm/data_handler/input_features.py
+++ b/farm/data_handler/input_features.py
@@ -201,15 +201,17 @@ def samples_to_features_bert_lm(sample, max_seq_len, tokenizer):
     :return: InputFeatures, containing all inputs and labels of one sample as IDs (as used for model training)
     """
 
-    tokens_a = tokenizer.tokenize(sample.clear_text["text_a"])
-    tokens_b = tokenizer.tokenize(sample.clear_text["text_b"])
+    tokens_a = sample.tokenized["text_a"]["tokens"]
+    tokens_b = sample.tokenized["text_b"]["tokens"]
     # Modifies `tokens_a` and `tokens_b` in place so that the total
     # length is less than the specified length.
     # Account for [CLS], [SEP], [SEP] with "- 3"
     truncate_seq_pair(tokens_a, tokens_b, max_seq_len - 3)
 
-    tokens_a, t1_label = mask_random_words(tokens_a, tokenizer)
-    tokens_b, t2_label = mask_random_words(tokens_b, tokenizer)
+    tokens_a, t1_label = mask_random_words(tokens_a, tokenizer.vocab,
+                                           token_groups=sample.tokenized["text_a"]["start_of_word"])
+    tokens_b, t2_label = mask_random_words(tokens_b, tokenizer.vocab,
+                                           token_groups=sample.tokenized["text_b"]["start_of_word"])
     # concatenate lm labels and account for CLS, SEP, SEP
     lm_label_ids = [-1] + t1_label + [-1] + t2_label + [-1]
 

--- a/farm/data_handler/input_features.py
+++ b/farm/data_handler/input_features.py
@@ -212,8 +212,12 @@ def samples_to_features_bert_lm(sample, max_seq_len, tokenizer):
                                            token_groups=sample.tokenized["text_a"]["start_of_word"])
     tokens_b, t2_label = mask_random_words(tokens_b, tokenizer.vocab,
                                            token_groups=sample.tokenized["text_b"]["start_of_word"])
+    # convert lm labels to ids
+    t1_label_ids = [-1 if tok == '' else tokenizer.vocab[tok] for tok in t1_label]
+    t2_label_ids = [-1 if tok == '' else tokenizer.vocab[tok] for tok in t2_label]
+
     # concatenate lm labels and account for CLS, SEP, SEP
-    lm_label_ids = [-1] + t1_label + [-1] + t2_label + [-1]
+    lm_label_ids = [-1] + t1_label_ids + [-1] + t2_label_ids + [-1]
 
     # The convention in BERT is:
     # (a) For sequence pairs:

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -677,7 +677,7 @@ class BertStyleLMProcessor(Processor):
         """ Overriding the method of the parent class here, because in this case we cannot simply convert one dict to samples.
         We need to know about the other dicts as well since we want with prob 50% to use sentences of other docs!
         So we operate directly on the baskets"""
-        self.baskets = create_samples_sentence_pairs(self.baskets)
+        self.baskets = create_samples_sentence_pairs(self.baskets, self.tokenizer, self.max_seq_len)
 
     def _dict_to_samples(self, dict):
         raise NotImplementedError

--- a/farm/data_handler/samples.py
+++ b/farm/data_handler/samples.py
@@ -1,5 +1,6 @@
 from farm.data_handler.utils import get_sentence_pair
 from pytorch_transformers.tokenization_bert import whitespace_tokenize
+from farm.modeling.tokenization import tokenize_with_metadata
 from farm.visual.ascii.images import SAMPLE
 from tqdm import tqdm
 
@@ -119,7 +120,7 @@ def create_sample_ner(split_text, label, basket_id):
     return [Sample(id=basket_id + "-0", clear_text={"text": text, "label": label})]
 
 
-def create_samples_sentence_pairs(baskets):
+def create_samples_sentence_pairs(baskets, tokenizer, max_seq_len):
     """Creates examples for Language Model Finetuning that consist of two sentences and the isNext label indicating if
      the two are subsequent sentences from one doc"""
     all_docs = [b.raw["doc"] for b in baskets]
@@ -134,7 +135,10 @@ def create_samples_sentence_pairs(baskets):
                 "text_b": text_b,
                 "is_next_label": is_next_label,
             }
-            basket.samples.append(Sample(id=id, clear_text=sample_in_clear_text))
+            tokenized = {}
+            tokenized["text_a"] = tokenize_with_metadata(text_a, tokenizer, max_seq_len)
+            tokenized["text_b"] = tokenize_with_metadata(text_a, tokenizer, max_seq_len)
+            basket.samples.append(Sample(id=id, clear_text=sample_in_clear_text, tokenized=tokenized))
     return baskets
 
 

--- a/farm/data_handler/samples.py
+++ b/farm/data_handler/samples.py
@@ -137,7 +137,7 @@ def create_samples_sentence_pairs(baskets, tokenizer, max_seq_len):
             }
             tokenized = {}
             tokenized["text_a"] = tokenize_with_metadata(text_a, tokenizer, max_seq_len)
-            tokenized["text_b"] = tokenize_with_metadata(text_a, tokenizer, max_seq_len)
+            tokenized["text_b"] = tokenize_with_metadata(text_b, tokenizer, max_seq_len)
             basket.samples.append(Sample(id=id, clear_text=sample_in_clear_text, tokenized=tokenized))
     return baskets
 

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -258,7 +258,7 @@ def mask_random_words(tokens, vocab, token_groups=None, max_predictions_per_seq=
 
     :param tokens: tokenized sentence.
     :type tokens: [str]
-    :param vocab: vocabulary for choosing tokens for random masking and converting tokens to IDs.
+    :param vocab: vocabulary for choosing tokens for random masking.
     :type vocab: dict
     :param token_groups: If supplied, only whole groups of tokens get masked. This can be whole words but
     also other types (e.g. spans). Booleans indicate the start of a group.
@@ -284,7 +284,7 @@ def mask_random_words(tokens, vocab, token_groups=None, max_predictions_per_seq=
                       max(1, int(round(len(tokens) * masked_lm_prob))))
 
     random.shuffle(cand_indices)
-    output_label = [-1]*len(tokens)
+    output_label = [''] * len(tokens)
     num_masked = 0
 
     # 2. Mask the first groups until we reach the number of tokens we wanted to mask (num_to_mask)
@@ -312,10 +312,10 @@ def mask_random_words(tokens, vocab, token_groups=None, max_predictions_per_seq=
 
             # append current token to output (we will predict these later)
             try:
-                output_label[index] = vocab[original_token]
+                output_label[index] = original_token
             except KeyError:
                 # For unknown words (should not occur with BPE vocab)
-                output_label[index] = vocab["[UNK]"]
+                output_label[index] = "[UNK]"
                 logger.warning(
                     "Cannot find token '{}' in vocab. Using [UNK] instead".format(original_token)
                 )

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -201,6 +201,7 @@ def get_sentence_pair(doc, all_docs, idx):
     """
     Get one sample from corpus consisting of two sentences. With prob. 50% these are two subsequent sentences
     from one doc. With 50% the second sentence will be a random one from another doc.
+
     :param idx: int, index of sample.
     :return: (str, str, int), sentence 1, sentence 2, isNextSentence Label
     """
@@ -220,6 +221,7 @@ def get_sentence_pair(doc, all_docs, idx):
 def _get_random_sentence(docs, forbidden_doc):
     """
     Get random line from another document for nextSentence task.
+
     :return: str, content of one line
     """
     # Similar to original BERT tf repo: This outer loop should rarely go for more than one iteration for large
@@ -239,43 +241,81 @@ def _get_random_sentence(docs, forbidden_doc):
     return sentence
 
 
-def mask_random_words(tokens, tokenizer):
+def mask_random_words(tokens, vocab, token_groups=None, max_predictions_per_seq=20, masked_lm_prob=0.15):
     """
     Masking some random tokens for Language Model task with probabilities as in the original BERT paper.
-    :param tokens: list of str, tokenized sentence.
-    :param tokenizer: Tokenizer, object used for tokenization (we need it's vocab here)
+    num_masked. If whole_word_mask is set to true, *all* tokens of a word are either masked or not.
+    This option was added by the BERT authors later and showed solid improvements compared to the original objective.
+    Whole Word Masking means that if we mask all of the wordpieces corresponding to an original word.
+    When a word has been split intoWordPieces, the first token does not have any marker and any subsequence
+    tokens are prefixed with ##. So whenever we see the ## token, we
+    append it to the previous set of word indexes. Note that Whole Word Masking does *not* change the training code
+    at all -- we still predict each WordPiece independently, softmaxed over the entire vocabulary.
+    This implementation is mainly a copy from the original code by Google, but includes some simplifications.
+
+    :param tokens: tokenized sentence.
+    :type tokens: [str]
+    :param vocab: vocabulary for choosing tokens for random masking and converting tokens to IDs.
+    :type vocab: dict
+    :param token_groups: If supplied, only whole groups of tokens get masked. This can be whole words but
+    also other types (e.g. spans). Booleans indicate the start of a group.
+    :type token_groups: [bool]
+    :param max_predictions_per_seq: maximum number of masked tokens
+    :type max_predictions_per_seq: int
+    :param masked_lm_prob: probability of masking a token
+    :type masked_lm_prob: float
     :return: (list of str, list of int), masked tokens and related labels for LM prediction
     """
-    output_label = []
 
-    for i, token in enumerate(tokens):
-        prob = random.random()
-        # mask token with 15% probability
-        if prob < 0.15:
-            prob /= 0.15
+    # 1. Combine tokens to one group (e.g. all subtokens of a word)
+    cand_indices = []
+    for (i, token) in enumerate(tokens):
+        if token == "[CLS]" or token == "[SEP]":
+            continue
+        if (token_groups and len(cand_indices) >= 1 and not token_groups[i]):
+            cand_indices[-1].append(i)
+        else:
+            cand_indices.append([i])
 
+    num_to_mask = min(max_predictions_per_seq,
+                      max(1, int(round(len(tokens) * masked_lm_prob))))
+
+    random.shuffle(cand_indices)
+    output_label = [-1]*len(tokens)
+    num_masked = 0
+
+    # 2. Mask the first groups until we reach the number of tokens we wanted to mask (num_to_mask)
+    for index_set in cand_indices:
+        if num_masked >= num_to_mask:
+            break
+        # If adding a whole-word mask would exceed the maximum number of
+        # predictions, then just skip this candidate.
+        if num_masked + len(index_set) > num_to_mask:
+            continue
+
+        for index in index_set:
+            prob = random.random()
+            num_masked += 1
+            original_token = tokens[index]
             # 80% randomly change token to mask token
             if prob < 0.8:
-                tokens[i] = "[MASK]"
+                tokens[index] = "[MASK]"
 
             # 10% randomly change token to random token
             elif prob < 0.9:
-                tokens[i] = random.choice(list(tokenizer.vocab.items()))[0]
+                tokens[index] = random.choice(list(vocab.items()))[0]
 
             # -> rest 10% randomly keep current token
 
             # append current token to output (we will predict these later)
             try:
-                output_label.append(tokenizer.vocab[token])
+                output_label[index] = vocab[original_token]
             except KeyError:
                 # For unknown words (should not occur with BPE vocab)
-                output_label.append(tokenizer.vocab["[UNK]"])
+                output_label[index] = vocab["[UNK]"]
                 logger.warning(
-                    "Cannot find token '{}' in vocab. Using [UNK] insetad".format(token)
+                    "Cannot find token '{}' in vocab. Using [UNK] instead".format(original_token)
                 )
-        else:
-            # no masking token (will be ignored by loss function later)
-            output_label.append(-1)
 
     return tokens, output_label
 

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -26,6 +26,7 @@ DOWNSTREAM_TASK_MAP = {
 def read_tsv(filename, quotechar='"', delimiter="\t", skiprows=None, columns=None):
     """Reads a tab separated value file. Tries to download the data if filename is not found"""
     if not (os.path.exists(filename)):
+        logger.info(f" Couldn't find {filename} locally. Trying to download ...")
         _download_extract_downstream_data(filename)
     df = pd.read_csv(
         filename,
@@ -48,6 +49,7 @@ def read_ner_file(filename, sep="\t", **kwargs):
     [ ['EU', 'B-ORG'], ['rejects', 'O'], ['German', 'B-MISC'], ['call', 'O'], ['to', 'O'], ['boycott', 'O'], ['British', 'B-MISC'], ['lamb', 'O'], ['.', 'O'] ]
     """
     if not (os.path.exists(filename)):
+        logger.info(f" Couldn't find {filename} locally. Trying to download ...")
         _download_extract_downstream_data(filename)
     f = open(filename)
 
@@ -73,6 +75,7 @@ def read_ner_file(filename, sep="\t", **kwargs):
 def read_squad_file(filename):
     """Read a SQuAD json file"""
     if not (os.path.exists(filename)):
+        logger.info(f" Couldn't find {filename} locally. Trying to download ...")
         _download_extract_downstream_data(filename)
     with open(filename, "r", encoding="utf-8") as reader:
         input_data = json.load(reader)["data"]

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -94,9 +94,9 @@ class AdaptiveModel(nn.Module):
         ph_output_type = []
         for config_file in ph_config_files:
             head = PredictionHead.load(config_file)
-            # set shared weights between LM and PH
-            if type(head) == BertLMHead:
-                head.set_shared_weights(language_model)
+            # # set shared weights between LM and PH
+            # if type(head) == BertLMHead:
+            #     head.set_shared_weights(language_model)
             prediction_heads.append(head)
             ph_output_type.append(head.ph_output_type)
 

--- a/test/samples/lm_finetuning/test-sample.txt
+++ b/test/samples/lm_finetuning/test-sample.txt
@@ -1,0 +1,34 @@
+Text should be one-sentence-per-line, with empty lines between documents.
+A Seentence to teest whoole woord maasking, muust includio multiplee woords wiith subwoord tookens.
+This text is included to make sure Unicode is handled properly: 力加勝北区ᴵᴺᵀᵃছজটডণত
+This sample text is public domain and was randomly selected from Project Guttenberg.
+
+The rain had only ceased with the gray streaks of morning at Blazing Star, and the settlement awoke to a moral sense of cleanliness, and the finding of forgotten knives, tin cups, and smaller camp utensils, where the heavy showers had washed away the debris and dust heaps before the cabin doors.
+Indeed, it was recorded in Blazing Star that a fortunate early riser had once picked up on the highway a solid chunk of gold quartz which the rain had freed from its incumbering soil, and washed into immediate and glittering popularity.
+Possibly this may have been the reason why early risers in that locality, during the rainy season, adopted a thoughtful habit of body, and seldom lifted their eyes to the rifted or india-ink washed skies above them.
+"Cass" Beard had risen early that morning, but not with a view to discovery.
+A leak in his cabin roof,--quite consistent with his careless, improvident habits,--had roused him at 4 A. M., with a flooded "bunk" and wet blankets.
+The chips from his wood pile refused to kindle a fire to dry his bed-clothes, and he had recourse to a more provident neighbor's to supply the deficiency.
+This was nearly opposite.
+Mr. Cassius crossed the highway, and stopped suddenly.
+Something glittered in the nearest red pool before him.
+Gold, surely!
+But, wonderful to relate, not an irregular, shapeless fragment of crude ore, fresh from Nature's crucible, but a bit of jeweler's handicraft in the form of a plain gold ring.
+Looking at it more attentively, he saw that it bore the inscription, "May to Cass."
+Like most of his fellow gold-seekers, Cass was superstitious.
+
+The fountain of classic wisdom, Hypatia herself.
+As the ancient sage--the name is unimportant to a monk--pumped water nightly that he might study by day, so I, the guardian of cloaks and parasols, at the sacred doors of her lecture-room, imbibe celestial knowledge.
+From my youth I felt in me a soul above the matter-entangled herd.
+She revealed to me the glorious fact, that I am a spark of Divinity itself.
+A fallen star, I am, sir!' continued he, pensively, stroking his lean stomach--'a fallen star!--fallen, if the dignity of philosophy will allow of the simile, among the hogs of the lower world--indeed, even into the hog-bucket itself. Well, after all, I will show you the way to the Archbishop's.
+There is a philosophic pleasure in opening one's treasures to the modest young.
+Perhaps you will assist me by carrying this basket of fruit?' And the little man jumped up, put his basket on Philammon's head, and trotted off up a neighbouring street.
+Philammon followed, half contemptuous, half wondering at what this philosophy might be, which could feed the self-conceit of anything so abject as his ragged little apish guide;
+but the novel roar and whirl of the street, the perpetual stream of busy faces, the line of curricles, palanquins, laden asses, camels, elephants, which met and passed him, and squeezed him up steps and into doorways, as they threaded their way through the great Moon-gate into the ample street beyond, drove everything from his mind but wondering curiosity, and a vague, helpless dread of that great living wilderness, more terrible than any dead wilderness of sand which he had left behind.
+Already he longed for the repose, the silence of the Laura--for faces which knew him and smiled upon him; but it was too late to turn back now.
+His guide held on for more than a mile up the great main street, crossed in the centre of the city, at right angles, by one equally magnificent, at each end of which, miles away, appeared, dim and distant over the heads of the living stream of passengers, the yellow sand-hills of the desert;
+while at the end of the vista in front of them gleamed the blue harbour, through a network of countless masts.
+At last they reached the quay at the opposite end of the street;
+and there burst on Philammon's astonished eyes a vast semicircle of blue sea, ringed with palaces and towers.
+He stopped involuntarily; and his little guide stopped also, and looked askance at the young monk, to watch the effect which that grand panorama should produce on him.

--- a/test/samples/lm_finetuning/train-sample.txt
+++ b/test/samples/lm_finetuning/train-sample.txt
@@ -1,0 +1,34 @@
+Text should be one-sentence-per-line, with empty lines between documents.
+A Seentence to teest whoole woord maasking, muust includio multiplee woords wiith subwoord tookens.
+This text is included to make sure Unicode is handled properly: 力加勝北区ᴵᴺᵀᵃছজটডণত
+This sample text is public domain and was randomly selected from Project Guttenberg.
+
+The rain had only ceased with the gray streaks of morning at Blazing Star, and the settlement awoke to a moral sense of cleanliness, and the finding of forgotten knives, tin cups, and smaller camp utensils, where the heavy showers had washed away the debris and dust heaps before the cabin doors.
+Indeed, it was recorded in Blazing Star that a fortunate early riser had once picked up on the highway a solid chunk of gold quartz which the rain had freed from its incumbering soil, and washed into immediate and glittering popularity.
+Possibly this may have been the reason why early risers in that locality, during the rainy season, adopted a thoughtful habit of body, and seldom lifted their eyes to the rifted or india-ink washed skies above them.
+"Cass" Beard had risen early that morning, but not with a view to discovery.
+A leak in his cabin roof,--quite consistent with his careless, improvident habits,--had roused him at 4 A. M., with a flooded "bunk" and wet blankets.
+The chips from his wood pile refused to kindle a fire to dry his bed-clothes, and he had recourse to a more provident neighbor's to supply the deficiency.
+This was nearly opposite.
+Mr. Cassius crossed the highway, and stopped suddenly.
+Something glittered in the nearest red pool before him.
+Gold, surely!
+But, wonderful to relate, not an irregular, shapeless fragment of crude ore, fresh from Nature's crucible, but a bit of jeweler's handicraft in the form of a plain gold ring.
+Looking at it more attentively, he saw that it bore the inscription, "May to Cass."
+Like most of his fellow gold-seekers, Cass was superstitious.
+
+The fountain of classic wisdom, Hypatia herself.
+As the ancient sage--the name is unimportant to a monk--pumped water nightly that he might study by day, so I, the guardian of cloaks and parasols, at the sacred doors of her lecture-room, imbibe celestial knowledge.
+From my youth I felt in me a soul above the matter-entangled herd.
+She revealed to me the glorious fact, that I am a spark of Divinity itself.
+A fallen star, I am, sir!' continued he, pensively, stroking his lean stomach--'a fallen star!--fallen, if the dignity of philosophy will allow of the simile, among the hogs of the lower world--indeed, even into the hog-bucket itself. Well, after all, I will show you the way to the Archbishop's.
+There is a philosophic pleasure in opening one's treasures to the modest young.
+Perhaps you will assist me by carrying this basket of fruit?' And the little man jumped up, put his basket on Philammon's head, and trotted off up a neighbouring street.
+Philammon followed, half contemptuous, half wondering at what this philosophy might be, which could feed the self-conceit of anything so abject as his ragged little apish guide;
+but the novel roar and whirl of the street, the perpetual stream of busy faces, the line of curricles, palanquins, laden asses, camels, elephants, which met and passed him, and squeezed him up steps and into doorways, as they threaded their way through the great Moon-gate into the ample street beyond, drove everything from his mind but wondering curiosity, and a vague, helpless dread of that great living wilderness, more terrible than any dead wilderness of sand which he had left behind.
+Already he longed for the repose, the silence of the Laura--for faces which knew him and smiled upon him; but it was too late to turn back now.
+His guide held on for more than a mile up the great main street, crossed in the centre of the city, at right angles, by one equally magnificent, at each end of which, miles away, appeared, dim and distant over the heads of the living stream of passengers, the yellow sand-hills of the desert;
+while at the end of the vista in front of them gleamed the blue harbour, through a network of countless masts.
+At last they reached the quay at the opposite end of the street;
+and there burst on Philammon's astonished eyes a vast semicircle of blue sea, ringed with palaces and towers.
+He stopped involuntarily; and his little guide stopped also, and looked askance at the young monk, to watch the effect which that grand panorama should produce on him.

--- a/test/test_lm_finetuning.py
+++ b/test/test_lm_finetuning.py
@@ -1,0 +1,85 @@
+
+import logging
+
+from farm.data_handler.data_silo import DataSilo
+from farm.data_handler.processor import BertStyleLMProcessor
+from farm.modeling.adaptive_model import AdaptiveModel
+from farm.modeling.language_model import Bert
+from farm.modeling.prediction_head import BertLMHead, NextSentenceHead
+from farm.modeling.tokenization import BertTokenizer
+from farm.train import Trainer
+from farm.experiment import initialize_optimizer
+from farm.infer import Inferencer
+
+from farm.utils import set_all_seeds, initialize_device_settings
+
+
+def test_lm_finetuning(caplog):
+    caplog.set_level(logging.CRITICAL)
+    set_all_seeds(seed=42)
+    device, n_gpu = initialize_device_settings(use_cuda=True)
+    n_epochs = 1
+    batch_size = 5
+    evaluate_every = 2
+    lang_model = "bert-base-cased"
+
+    tokenizer = BertTokenizer.from_pretrained(
+        pretrained_model_name_or_path=lang_model, do_lower_case=False
+    )
+
+    processor = BertStyleLMProcessor(
+        data_dir="samples/lm_finetuning",
+        train_filename="train-sample.txt",
+        test_filename="test-sample.txt",
+        dev_filename=None,
+        tokenizer=tokenizer, max_seq_len=64
+    )
+    data_silo = DataSilo(processor=processor, batch_size=batch_size)
+
+    language_model = Bert.load(lang_model)
+    lm_prediction_head = BertLMHead.load(lang_model)
+    next_sentence_head = NextSentenceHead.load(lang_model)
+
+    model = AdaptiveModel(
+        language_model=language_model,
+        prediction_heads=[lm_prediction_head, next_sentence_head],
+        embeds_dropout_prob=0.1,
+        lm_output_types=["per_token", "per_sequence"],
+        device=device,
+    )
+
+    optimizer, warmup_linear = initialize_optimizer(
+        model=model,
+        learning_rate=2e-5,
+        warmup_proportion=0.1,
+        n_examples=data_silo.n_samples("train"),
+        batch_size=batch_size,
+        n_epochs=n_epochs,
+    )
+
+    trainer = Trainer(
+        optimizer=optimizer,
+        data_silo=data_silo,
+        epochs=n_epochs,
+        n_gpu=n_gpu,
+        warmup_linear=warmup_linear,
+        evaluate_every=evaluate_every,
+        device=device,
+    )
+
+    model = trainer.train(model)
+
+    save_dir = "testsave/lm_finetuning"
+    model.save(save_dir)
+    processor.save(save_dir)
+
+    #TODO: inferencer needs to get a new minimalist processor for vector extraction.
+    # The stored BertStyleLM is not what we need here.
+
+    # basic_texts = [
+    #     {"text": "Farmer's life is great."}
+    #     {"text": "It's nothing for big city kids though."},
+    # ]
+    # model = Inferencer.load(save_dir)
+    # result = model.extract_vectors(dicts=basic_texts)
+    # print(result)


### PR DESCRIPTION
This adds whole word masking as an option to the masked language model objective. As described by Jacob Devlin, this is likely to boost performance by ~ 1%. 

In contrast to the google and pytorch-transformers codebase, I have tried to make it more generic so that we can use a similar approach in the future for masking any token groups (e.g. spans / entities /...) 