### PR TITLE
Add multi-gpu support for "building blocks" mode

### DIFF
--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -80,7 +80,7 @@ trainer = Trainer(
     device=device,
 )
 
-# 7. Let it grow! Watch the tracked metrics live on the public mlflow server: http://80.158.39.167:5000/
+# 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai
 model = trainer.train(model)
 
 # 8. Hooray! You have a model. Store it:

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -83,7 +83,7 @@ trainer = Trainer(
     evaluate_every=evaluate_every,
     device=device,
 )
-# 7. Let it grow! Watch the tracked metrics live on the public mlflow server: http://80.158.39.167:5000/
+# 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai
 model = trainer.train(model)
 
 # 8. Hooray! You have a model. Store it:

--- a/farm/experiment.py
+++ b/farm/experiment.py
@@ -76,10 +76,7 @@ def run_experiment(args):
         model=args.model,
         device=device,
         class_weights=class_weights,
-        fp16=args.fp16,
         embeds_dropout_prob=args.embeds_dropout_prob,
-        local_rank=args.local_rank,
-        n_gpu=n_gpu,
     )
 
     # Init optimizer
@@ -103,6 +100,7 @@ def run_experiment(args):
         n_gpu=n_gpu,
         grad_acc_steps=args.gradient_accumulation_steps,
         fp16=args.fp16,
+        local_rank=args.local_rank,
         warmup_linear=warmup_linear,
         evaluate_every=args.eval_every,
         device=device,
@@ -124,9 +122,6 @@ def get_adaptive_model(
     model,
     device,
     embeds_dropout_prob,
-    local_rank,
-    n_gpu,
-    fp16=False,
     class_weights=None,
 ):
     parsed_lm_output_types = lm_output_type.split(",")
@@ -151,14 +146,6 @@ def get_adaptive_model(
         lm_output_types=parsed_lm_output_types,
         device=device,
     )
-    if fp16:
-        model.half()
-
-    if local_rank > -1:
-        model = WrappedDDP(model)
-    elif n_gpu > 1:
-        model = WrappedDataParallel(model)
-
     return model
 
 

--- a/test/test_lm_finetuning.py
+++ b/test/test_lm_finetuning.py
@@ -52,8 +52,7 @@ def test_lm_finetuning(caplog):
         model=model,
         learning_rate=2e-5,
         warmup_proportion=0.1,
-        n_examples=data_silo.n_samples("train"),
-        batch_size=batch_size,
+        n_batches=len(data_silo.loaders["train"]),
         n_epochs=n_epochs,
     )
 

--- a/test/test_question_answering.py
+++ b/test/test_question_answering.py
@@ -36,7 +36,7 @@ def test_qa(caplog):
         data_dir="samples/qa",
     )
 
-    data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False)
+    data_silo = DataSilo(processor=processor, batch_size=batch_size)
     language_model = Bert.load(base_LM_model)
     prediction_head = QuestionAnsweringHead(layer_dims=[768, len(processor.label_list)])
     model = AdaptiveModel(


### PR DESCRIPTION
This fixes #57 by moving the parallelization part to `Trainer.train()`. This seems to be a decent place since we have all the args already present there and it should also happen after initalization of the optimizer to avoid issues with apex. If we want multi gpu for the inferencer, we will need to add it there later as well.  But for now this seems to be a rare edge case ...