### PR TITLE
Label Type casting in TextClassificationProcessor

### DIFF
--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -35,8 +35,8 @@ def read_tsv(filename, quotechar='"', delimiter="\t", skiprows=None, columns=Non
         quotechar=quotechar,
         names=columns,
         skiprows=skiprows,
+        dtype=str, 
     )
-    df['label'] = df['label'].astype(str)
     if "unused" in df.columns:
         df.drop(columns=["unused"], inplace=True)
     raw_dict = df.to_dict(orient="records")


### PR DESCRIPTION
Casting all labels to strings to suppress the type conversion from pandas when reading files. 
This fixes issue #66 