### PR TITLE
Add user friendly error message for wrong doc input format

### DIFF
--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -141,9 +141,19 @@ def read_docs_from_txt(filename, delimiter="", encoding="utf-8"):
             else:
                 doc.append(line)
 
-        # if last row in file is not empty
-        if all_docs[-1] != doc and len(doc) > 0:
-            all_docs.append({"doc": doc})
+        # if last row in file is not empty, we add the last parsed doc manually to all_docs
+        if len(doc) > 0:
+            if len(all_docs) > 0:
+                if all_docs[-1] != doc:
+                    all_docs.append({"doc": doc})
+            else:
+                all_docs.append({"doc": doc})
+
+        if len(all_docs) < 2:
+            raise ValueError(f"Found only {len(all_docs)} docs in {filename}). You need at least 2! \n"
+                           f"Make sure that you comply with the format: \n"
+                           f"-> One sentence per line and exactly *one* empty line between docs. \n"
+                           f"You might have a single block of text without empty lines inbetween.")
     return all_docs
 
 


### PR DESCRIPTION
This adresses #48, where we agreed that we want some more descriptive error message for the case when people put in a wrong document format for LM finetuning. We want to make sure that the user has at least 2 docs splitted by an empty line.  