### PR TITLE
Add max number of docs to read from file

### DIFF
--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -40,7 +40,7 @@ tokenizer = BertTokenizer.from_pretrained(
 
 # 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
 processor = BertStyleLMProcessor(
-    data_dir="../data/lm_finetune_nips", tokenizer=tokenizer, max_seq_len=128
+    data_dir="../data/lm_finetune_nips", tokenizer=tokenizer, max_seq_len=128, max_docs=30
 )
 # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
 data_silo = DataSilo(processor=processor, batch_size=batch_size)

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -583,6 +583,7 @@ class BertStyleLMProcessor(Processor):
         dev_filename="dev.txt",
         test_filename="test.txt",
         dev_split=0.0,
+        max_docs=None,
         **kwargs,
     ):
         # General Processor attributes
@@ -594,6 +595,7 @@ class BertStyleLMProcessor(Processor):
 
         # Custom attributes
         self.delimiter = ""
+        self.max_docs = max_docs
 
         super(BertStyleLMProcessor, self).__init__(
             tokenizer=tokenizer,
@@ -611,7 +613,7 @@ class BertStyleLMProcessor(Processor):
         )
 
     def _file_to_dicts(self, file: str) -> list:
-        dicts = read_docs_from_txt(filename=file, delimiter=self.delimiter)
+        dicts = read_docs_from_txt(filename=file, delimiter=self.delimiter, max_docs=self.max_docs)
         return dicts
 
     @classmethod

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -119,7 +119,7 @@ def _conll03get(dataset, directory):
         file.write(response.content)
 
 
-def read_docs_from_txt(filename, delimiter="", encoding="utf-8"):
+def read_docs_from_txt(filename, delimiter="", encoding="utf-8", max_docs=None):
     """Reads a text file with one sentence per line and a delimiter between docs (default: empty lines) ."""
     if not (os.path.exists(filename)):
         _download_extract_downstream_data(filename)
@@ -133,6 +133,10 @@ def read_docs_from_txt(filename, delimiter="", encoding="utf-8"):
                 if len(doc) > 0:
                     all_docs.append({"doc": doc})
                     doc = []
+                    if max_docs:
+                        if len(all_docs) >= max_docs:
+                            logger.info(f"Reached number of max_docs ({max_docs}). Skipping rest of file ...")
+                            break
                 else:
                     logger.warning(f"Found empty document in file (line {line_num}). "
                                    f"Make sure that you comply with the format: "


### PR DESCRIPTION
Processing data for LM finetuning can take quite some time for larger data sets. Let's add an option `max_docs` to limit the number of docs that are read from a file. 

We can use this option for debugging, but also in our example script: people can execute the whole example in a few minutes, but still have the option to easily extend this to the whole dataset.