### PR TITLE
Use file_descriptor as the sharing strategy for pytorch multiprocessing

### DIFF
--- a/farm/__init__.py
+++ b/farm/__init__.py
@@ -1,5 +1,7 @@
 import logging
-import torch
+import resource
+
+import torch.multiprocessing as mp
 
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
@@ -7,5 +9,9 @@ logging.basicConfig(
     level=logging.INFO,
 )
 
-# fix for a file descriptor issue when using multiprocessing: https://github.com/pytorch/pytorch/issues/973
-torch.multiprocessing.set_sharing_strategy("file_system")
+# https://pytorch.org/docs/stable/multiprocessing.html#sharing-strategies
+if "file_descriptor" in mp.get_all_sharing_strategies():
+    mp.set_sharing_strategy("file_descriptor")
+
+    rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (10_000, rlimit[1]))

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -1,15 +1,14 @@
 import copy
 import logging
-import multiprocessing as mp
+import torch.multiprocessing as mp
 import os
 from contextlib import ExitStack
 from functools import partial
 import random
 
 import numpy as np
-from sklearn.model_selection import train_test_split
 from sklearn.utils.class_weight import compute_class_weight
-from torch.utils.data import ConcatDataset, DataLoader, random_split, Subset, Dataset
+from torch.utils.data import ConcatDataset, Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, SequentialSampler
 from tqdm import tqdm


### PR DESCRIPTION
As per the recommended best practices in Pytorch documentation(https://pytorch.org/docs/stable/multiprocessing.html#sharing-strategies), `file_descriptor` sharing strategy is used when available and the limit of open file descriptions is elevated.  