### PR TITLE
Add method to run inference from a file

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -79,5 +79,5 @@ b) and a prediction head on top that is suited for our task => Text classificati
         {"text": "Martin Müller spielt Fussball"},
     ]
     model = Inferencer(save_dir)
-    result = model.run_inference(dicts=basic_texts)
+    result = model.inference_from_dicts(dicts=basic_texts)
     print(result)

--- a/examples/doc_classification.py
+++ b/examples/doc_classification.py
@@ -102,7 +102,7 @@ basic_texts = [
     {"text": "Martin Müller spielt Handball in Berlin"},
 ]
 model = Inferencer.load(save_dir)
-result = model.run_inference(dicts=basic_texts)
+result = model.inference_from_dicts(dicts=basic_texts)
 print(result)
 
 # fmt: on

--- a/examples/doc_classification_multilabel.py
+++ b/examples/doc_classification_multilabel.py
@@ -106,7 +106,7 @@ basic_texts = [
     {"text": "What a lovely world"},
 ]
 model = Inferencer.load(save_dir)
-result = model.run_inference(dicts=basic_texts)
+result = model.inference_from_dicts(dicts=basic_texts)
 print(result)
 
 

--- a/examples/doc_regression.py
+++ b/examples/doc_regression.py
@@ -94,7 +94,7 @@ basic_texts = [
     {"text": ""},
 ]
 model = Inferencer.load(save_dir)
-result = model.run_inference(dicts=basic_texts)
+result = model.inference_from_dicts(dicts=basic_texts)
 
 print(result)
 

--- a/examples/ner.py
+++ b/examples/ner.py
@@ -96,5 +96,5 @@ basic_texts = [
     {"text": "Martin Müller spielt Handball in Berlin"},
 ]
 model = Inferencer.load(save_dir)
-result = model.run_inference(dicts=basic_texts)
+result = model.inference_from_dicts(dicts=basic_texts)
 print(result)

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -104,7 +104,7 @@ QA_input = [
         }]
 
 model = Inferencer.load(save_dir)
-result = model.run_inference(dicts=QA_input)
+result = model.inference_from_dicts(dicts=QA_input)
 
 for x in result:
     pprint.pprint(x)

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -22,89 +22,89 @@ logging.basicConfig(
 ml_logger = MLFlowLogger(tracking_uri="https://public-mlflow.deepset.ai/")
 ml_logger.init_experiment(experiment_name="Public_FARM", run_name="Run_question_answering")
 
-# ##########################
-# ########## Settings
-# ##########################
-# set_all_seeds(seed=42)
-# device, n_gpu = initialize_device_settings(use_cuda=True)
-# batch_size = 24
-# n_epochs = 2
-# evaluate_every = 500
-# base_LM_model = "bert-base-cased"
-# train_filename="train-v2.0.json"
-# dev_filename="dev-v2.0.json"
-#
-# # 1.Create a tokenizer
-# tokenizer = BertTokenizer.from_pretrained(
-#     pretrained_model_name_or_path=base_LM_model, do_lower_case=False
-# )
-# # 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
-# label_list = ["start_token", "end_token"]
-# metric = "squad"
-# processor = SquadProcessor(
-#     tokenizer=tokenizer,
-#     max_seq_len=256,
-#     labels=label_list,
-#     metric=metric,
-#     train_filename=train_filename,
-#     dev_filename=dev_filename,
-#     test_filename=None,
-#     data_dir="../data/squad20",
-# )
-#
-#
-# # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
-# data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False)
-#
-# # 4. Create an AdaptiveModel
-# # a) which consists of a pretrained language model as a basis
-# language_model = Bert.load(base_LM_model)
-# # b) and a prediction head on top that is suited for our task => Question Answering
-# prediction_head = QuestionAnsweringHead(layer_dims=[768, len(label_list)])
-#
-# model = AdaptiveModel(
-#     language_model=language_model,
-#     prediction_heads=[prediction_head],
-#     embeds_dropout_prob=0.1,
-#     lm_output_types=["per_token"],
-#     device=device,
-# )
-#
-# # 5. Create an optimizer
-# optimizer, warmup_linear = initialize_optimizer(
-#     model=model,
-#     learning_rate=1e-5,
-#     warmup_proportion=0.2,
-#     n_batches=len(data_silo.loaders["train"]),
-#     n_epochs=n_epochs,
-# )
-# # 6. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
-# trainer = Trainer(
-#     optimizer=optimizer,
-#     data_silo=data_silo,
-#     epochs=n_epochs,
-#     n_gpu=n_gpu,
-#     warmup_linear=warmup_linear,
-#     evaluate_every=evaluate_every,
-#     device=device,
-# )
-# # 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai
-# model = trainer.train(model)
-#
-# # 8. Hooray! You have a model. Store it:
-# save_dir = "../saved_models/bert-english-qa-tutorial"
-# model.save(save_dir)
-# processor.save(save_dir)
-#
-# # 9. Load it & harvest your fruits (Inference)
-# QA_input = [
-#         {
-#             "questions": ["Who counted the game among the best ever made?"],
-#             "text":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
-#         }]
-save_dir = "base_models/bert-base-cased-english-SQUAD20"
+##########################
+########## Settings
+##########################
+set_all_seeds(seed=42)
+device, n_gpu = initialize_device_settings(use_cuda=True)
+batch_size = 24
+n_epochs = 2
+evaluate_every = 500
+base_LM_model = "bert-base-cased"
+train_filename="train-v2.0.json"
+dev_filename="dev-v2.0.json"
+
+# 1.Create a tokenizer
+tokenizer = BertTokenizer.from_pretrained(
+    pretrained_model_name_or_path=base_LM_model, do_lower_case=False
+)
+# 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
+label_list = ["start_token", "end_token"]
+metric = "squad"
+processor = SquadProcessor(
+    tokenizer=tokenizer,
+    max_seq_len=256,
+    labels=label_list,
+    metric=metric,
+    train_filename=train_filename,
+    dev_filename=dev_filename,
+    test_filename=None,
+    data_dir="../data/squad20",
+)
+
+
+# 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
+data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False)
+
+# 4. Create an AdaptiveModel
+# a) which consists of a pretrained language model as a basis
+language_model = Bert.load(base_LM_model)
+# b) and a prediction head on top that is suited for our task => Question Answering
+prediction_head = QuestionAnsweringHead(layer_dims=[768, len(label_list)])
+
+model = AdaptiveModel(
+    language_model=language_model,
+    prediction_heads=[prediction_head],
+    embeds_dropout_prob=0.1,
+    lm_output_types=["per_token"],
+    device=device,
+)
+
+# 5. Create an optimizer
+optimizer, warmup_linear = initialize_optimizer(
+    model=model,
+    learning_rate=1e-5,
+    warmup_proportion=0.2,
+    n_batches=len(data_silo.loaders["train"]),
+    n_epochs=n_epochs,
+)
+# 6. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
+trainer = Trainer(
+    optimizer=optimizer,
+    data_silo=data_silo,
+    epochs=n_epochs,
+    n_gpu=n_gpu,
+    warmup_linear=warmup_linear,
+    evaluate_every=evaluate_every,
+    device=device,
+)
+# 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai
+model = trainer.train(model)
+
+# 8. Hooray! You have a model. Store it:
+save_dir = "../saved_models/bert-english-qa-tutorial"
+model.save(save_dir)
+processor.save(save_dir)
+
+# 9. Load it & harvest your fruits (Inference)
+QA_input = [
+        {
+            "questions": ["Who counted the game among the best ever made?"],
+            "text":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
+        }]
+
 model = Inferencer.load(save_dir)
-result = model.inference_from_file(file="/Users/tanay/data/squad20/dev-v2.0.json")
+result = model.inference_from_dicts(dicts=QA_input)
 
 for x in result:
     pprint.pprint(x)

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -22,89 +22,89 @@ logging.basicConfig(
 ml_logger = MLFlowLogger(tracking_uri="https://public-mlflow.deepset.ai/")
 ml_logger.init_experiment(experiment_name="Public_FARM", run_name="Run_question_answering")
 
-##########################
-########## Settings
-##########################
-set_all_seeds(seed=42)
-device, n_gpu = initialize_device_settings(use_cuda=True)
-batch_size = 24
-n_epochs = 2
-evaluate_every = 500
-base_LM_model = "bert-base-cased"
-train_filename="train-v2.0.json"
-dev_filename="dev-v2.0.json"
-
-# 1.Create a tokenizer
-tokenizer = BertTokenizer.from_pretrained(
-    pretrained_model_name_or_path=base_LM_model, do_lower_case=False
-)
-# 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
-label_list = ["start_token", "end_token"]
-metric = "squad"
-processor = SquadProcessor(
-    tokenizer=tokenizer,
-    max_seq_len=256,
-    labels=label_list,
-    metric=metric,
-    train_filename=train_filename,
-    dev_filename=dev_filename,
-    test_filename=None,
-    data_dir="../data/squad20",
-)
-
-
-# 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
-data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False)
-
-# 4. Create an AdaptiveModel
-# a) which consists of a pretrained language model as a basis
-language_model = Bert.load(base_LM_model)
-# b) and a prediction head on top that is suited for our task => Question Answering
-prediction_head = QuestionAnsweringHead(layer_dims=[768, len(label_list)])
-
-model = AdaptiveModel(
-    language_model=language_model,
-    prediction_heads=[prediction_head],
-    embeds_dropout_prob=0.1,
-    lm_output_types=["per_token"],
-    device=device,
-)
-
-# 5. Create an optimizer
-optimizer, warmup_linear = initialize_optimizer(
-    model=model,
-    learning_rate=1e-5,
-    warmup_proportion=0.2,
-    n_batches=len(data_silo.loaders["train"]),
-    n_epochs=n_epochs,
-)
-# 6. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
-trainer = Trainer(
-    optimizer=optimizer,
-    data_silo=data_silo,
-    epochs=n_epochs,
-    n_gpu=n_gpu,
-    warmup_linear=warmup_linear,
-    evaluate_every=evaluate_every,
-    device=device,
-)
-# 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai
-model = trainer.train(model)
-
-# 8. Hooray! You have a model. Store it:
-save_dir = "../saved_models/bert-english-qa-tutorial"
-model.save(save_dir)
-processor.save(save_dir)
-
-# 9. Load it & harvest your fruits (Inference)
-QA_input = [
-        {
-            "questions": ["Who counted the game among the best ever made?"],
-            "text":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
-        }]
-
+# ##########################
+# ########## Settings
+# ##########################
+# set_all_seeds(seed=42)
+# device, n_gpu = initialize_device_settings(use_cuda=True)
+# batch_size = 24
+# n_epochs = 2
+# evaluate_every = 500
+# base_LM_model = "bert-base-cased"
+# train_filename="train-v2.0.json"
+# dev_filename="dev-v2.0.json"
+#
+# # 1.Create a tokenizer
+# tokenizer = BertTokenizer.from_pretrained(
+#     pretrained_model_name_or_path=base_LM_model, do_lower_case=False
+# )
+# # 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
+# label_list = ["start_token", "end_token"]
+# metric = "squad"
+# processor = SquadProcessor(
+#     tokenizer=tokenizer,
+#     max_seq_len=256,
+#     labels=label_list,
+#     metric=metric,
+#     train_filename=train_filename,
+#     dev_filename=dev_filename,
+#     test_filename=None,
+#     data_dir="../data/squad20",
+# )
+#
+#
+# # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
+# data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False)
+#
+# # 4. Create an AdaptiveModel
+# # a) which consists of a pretrained language model as a basis
+# language_model = Bert.load(base_LM_model)
+# # b) and a prediction head on top that is suited for our task => Question Answering
+# prediction_head = QuestionAnsweringHead(layer_dims=[768, len(label_list)])
+#
+# model = AdaptiveModel(
+#     language_model=language_model,
+#     prediction_heads=[prediction_head],
+#     embeds_dropout_prob=0.1,
+#     lm_output_types=["per_token"],
+#     device=device,
+# )
+#
+# # 5. Create an optimizer
+# optimizer, warmup_linear = initialize_optimizer(
+#     model=model,
+#     learning_rate=1e-5,
+#     warmup_proportion=0.2,
+#     n_batches=len(data_silo.loaders["train"]),
+#     n_epochs=n_epochs,
+# )
+# # 6. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
+# trainer = Trainer(
+#     optimizer=optimizer,
+#     data_silo=data_silo,
+#     epochs=n_epochs,
+#     n_gpu=n_gpu,
+#     warmup_linear=warmup_linear,
+#     evaluate_every=evaluate_every,
+#     device=device,
+# )
+# # 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai
+# model = trainer.train(model)
+#
+# # 8. Hooray! You have a model. Store it:
+# save_dir = "../saved_models/bert-english-qa-tutorial"
+# model.save(save_dir)
+# processor.save(save_dir)
+#
+# # 9. Load it & harvest your fruits (Inference)
+# QA_input = [
+#         {
+#             "questions": ["Who counted the game among the best ever made?"],
+#             "text":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
+#         }]
+save_dir = "base_models/bert-base-cased-english-SQUAD20"
 model = Inferencer.load(save_dir)
-result = model.inference_from_dicts(dicts=QA_input)
+result = model.inference_from_file(file="/Users/tanay/data/squad20/dev-v2.0.json")
 
 for x in result:
     pprint.pprint(x)

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -56,7 +56,7 @@ class DataSilo:
         return dataset
 
     def _get_dataset(self, filename):
-        dicts = self.processor._file_to_dicts(filename)
+        dicts = self.processor.file_to_dicts(filename)
         #shuffle list of dicts here if we later want to have a random dev set splitted from train set
         if filename == self.processor.train_filename:
             if not self.processor.dev_filename:

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -308,8 +308,8 @@ class Processor(ABC):
     #     dataset, tensor_names = self._create_dataset()
     #     return dataset, tensor_names
 
-    #TODO remove useless from_inference flag after refactoring squad processing
-    def dataset_from_dicts(self, dicts, index=None, from_inference=False):
+    #TODO remove useless rest_api_schema flag after refactoring squad processing
+    def dataset_from_dicts(self, dicts, index=None, rest_api_schema=False):
         """
         Contains all the functionality to turn a list of dict objects into a PyTorch Dataset and a
         list of tensor names. This can be used for inference mode.

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -717,10 +717,10 @@ class SquadProcessor(Processor):
         if metric and labels:
             self.add_task("question_answering", metric, labels)
 
-    def dataset_from_dicts(self, dicts, index=None, from_inference=False):
-        if(from_inference):
-            dicts = [self._convert_inference(x) for x in dicts]
-        if(from_inference):
+    def dataset_from_dicts(self, dicts, index=None, rest_api_schema=False):
+        if rest_api_schema:
+            dicts = [self._convert_rest_api_dict(x) for x in dicts]
+        if rest_api_schema:
             id_prefix = "infer"
         else:
             id_prefix = "train"
@@ -735,7 +735,7 @@ class SquadProcessor(Processor):
         dataset, tensor_names = self._create_dataset()
         return dataset, tensor_names
 
-    def _convert_inference(self, infer_dict):
+    def _convert_rest_api_dict(self, infer_dict):
         # convert input coming from inferencer to SQuAD format
         converted = {}
         converted["paragraphs"] = [
@@ -757,7 +757,7 @@ class SquadProcessor(Processor):
 
     def _dict_to_samples(self, dictionary: dict, **kwargs) -> [Sample]:
         if "paragraphs" not in dictionary:  # TODO change this inference mode hack
-            dictionary = self._convert_inference(infer_dict=dictionary)
+            dictionary = self._convert_rest_api_dict(infer_dict=dictionary)
         samples = create_samples_squad(entry=dictionary)
         for sample in samples:
             tokenized = tokenize_with_metadata(

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -4,6 +4,7 @@ from abc import ABC
 import random
 import logging
 import json
+import time
 import inspect
 from inspect import signature
 import numpy as np
@@ -41,7 +42,7 @@ class Processor(ABC):
     """
     Is used to generate PyTorch Datasets from input data. An implementation of this abstract class should be created
     for each new data source.
-    Implement the abstract methods: _file_to_dicts(), _dict_to_samples(), _sample_to_features()
+    Implement the abstract methods: file_to_dicts(), _dict_to_samples(), _sample_to_features()
     to be compatible with your data format
     """
 
@@ -236,7 +237,7 @@ class Processor(ABC):
         }
 
     @abc.abstractmethod
-    def _file_to_dicts(self, file: str) -> [dict]:
+    def file_to_dicts(self, file: str) -> [dict]:
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -248,7 +249,7 @@ class Processor(ABC):
         raise NotImplementedError()
 
     def _init_baskets_from_file(self, file):
-        dicts = self._file_to_dicts(file)
+        dicts = self.file_to_dicts(file)
         dataset_name = os.path.splitext(os.path.basename(file))[0]
         baskets = [
             SampleBasket(raw=tr, id=f"{dataset_name}-{i}") for i, tr in enumerate(dicts)
@@ -406,7 +407,7 @@ class TextClassificationProcessor(Processor):
                           label_column_name=label_column_name,
                           task_type=task_type)
 
-    def _file_to_dicts(self, file: str) -> [dict]:
+    def file_to_dicts(self, file: str) -> [dict]:
         column_mapping = {task["label_column_name"]: task["label_name"] for task in self.tasks.values()}
         dicts = read_tsv(
             filename=file,
@@ -497,7 +498,7 @@ class InferenceProcessor(Processor):
         return processor
 
 
-    def _file_to_dicts(self, file: str) -> [dict]:
+    def file_to_dicts(self, file: str) -> [dict]:
       raise NotImplementedError
 
     def _dict_to_samples(self, dictionary: dict, **kwargs) -> [Sample]:
@@ -554,7 +555,7 @@ class NERProcessor(Processor):
         if metric and label_list:
             self.add_task("ner", metric, label_list)
 
-    def _file_to_dicts(self, file: str) -> [dict]:
+    def file_to_dicts(self, file: str) -> [dict]:
         dicts = read_ner_file(filename=file, sep=self.delimiter)
         return dicts
 
@@ -616,7 +617,7 @@ class BertStyleLMProcessor(Processor):
             self.add_task("nextsentence", "acc", ["False", "True"])
 
 
-    def _file_to_dicts(self, file: str) -> list:
+    def file_to_dicts(self, file: str) -> list:
         dicts = read_docs_from_txt(filename=file, delimiter=self.delimiter, max_docs=self.max_docs)
         return dicts
 
@@ -750,7 +751,7 @@ class SquadProcessor(Processor):
         ]
         return converted
 
-    def _file_to_dicts(self, file: str) -> [dict]:
+    def file_to_dicts(self, file: str) -> [dict]:
         dict = read_squad_file(filename=file)
         return dict
 
@@ -822,7 +823,7 @@ class RegressionProcessor(Processor):
         self.add_task(name="regression", metric="mse", label_list= [scaler_mean, scaler_scale], label_column_name=label_column_name, task_type="regression", label_name=label_name)
 
 
-    def _file_to_dicts(self, file: str) -> [dict]:
+    def file_to_dicts(self, file: str) -> [dict]:
         column_mapping = {task["label_column_name"]: task["label_name"] for task in self.tasks.values()}
         dicts = read_tsv(
             rename_columns=column_mapping,

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -184,7 +184,7 @@ class Inferencer:
             preds_all = []
             with tqdm(total=len(dicts), unit=" Dicts") as pbar:
                 for dataset, tensor_names, sample in results:
-                    preds_all.append(self._run_inference(dataset, tensor_names, sample))
+                    preds_all.extend(self._run_inference(dataset, tensor_names, sample))
                     pbar.update(self.multiprocessing_chunk_size)
 
         return preds_all

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -138,15 +138,17 @@ class Inferencer:
             )
 
             preds_all = []
-            for dataset, tensor_names, sample in tqdm(results, total=dict_batches_to_process):
-                preds_all.append(self._run_inference(dataset, tensor_names, sample))
+            with tqdm(total=len(dicts), unit=' Dicts') as pbar:
+                for dataset, tensor_names, sample in results:
+                    preds_all.append(self._run_inference(dataset, tensor_names, sample))
+                    pbar.update(self.multiprocessing_chunk_size)
 
         return preds_all
 
     @classmethod
     def _multiproc_dict_to_samples(cls, dicts, processor):
         dicts_list = [dicts]
-        dataset, tensor_names = processor.dataset_from_dicts(dicts_list, from_inference=True)
+        dataset, tensor_names = processor.dataset_from_dicts(dicts_list)
         samples = []
         for d in dicts_list:
             samples.extend(processor._dict_to_samples(d))

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -196,7 +196,7 @@ class Inferencer:
                 "a) ... extract vectors from the language model: call `Inferencer.extract_vectors(...)`"
                 f"b) ... run inference on a downstream task: make sure your model path {self.name} contains a saved prediction head"
             )
-        dataset, tensor_names = self.processor.dataset_from_dicts(dicts, from_inference=True)
+        dataset, tensor_names = self.processor.dataset_from_dicts(dicts, rest_api_schema=True)
         samples = []
         for dict in dicts:
             samples.extend(self.processor._dict_to_samples(dict))
@@ -221,7 +221,7 @@ class Inferencer:
         :return: dict of predictions
         """
 
-        dataset, tensor_names = self.processor.dataset_from_dicts(dicts, from_inference=True)
+        dataset, tensor_names = self.processor.dataset_from_dicts(dicts, rest_api_schema=True)
         samples = []
         for dict in dicts:
             samples.extend(self.processor._dict_to_samples(dict))

--- a/farm/inference_rest_api.py
+++ b/farm/inference_rest_api.py
@@ -79,7 +79,7 @@ class InferenceEndpoint(Resource):
         dicts = request.get_json().get("input", None)
         if not dicts:
             return {}
-        results = model.run_inference(dicts=dicts)
+        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True)
         return results[0]
 
 

--- a/test/test_doc_classification.py
+++ b/test/test_doc_classification.py
@@ -79,7 +79,7 @@ def test_doc_classification(caplog):
 
 
     inf = Inferencer.load(save_dir,batch_size=2)
-    result = inf.run_inference(dicts=basic_texts)
+    result = inf.inference_from_dicts(dicts=basic_texts)
     assert isinstance(result[0]["predictions"][0]["probability"],np.float32)
 
 

--- a/test/test_doc_regression.py
+++ b/test/test_doc_regression.py
@@ -75,7 +75,7 @@ def test_doc_regression(caplog):
     ]
 
     model = Inferencer.load(save_dir)
-    result = model.run_inference(dicts=basic_texts)
+    result = model.inference_from_dicts(dicts=basic_texts)
     assert isinstance(result[0]["predictions"][0]["pred"], np.float32)
 
 if(__name__=="__main__"):

--- a/test/test_ner.py
+++ b/test/test_ner.py
@@ -75,7 +75,7 @@ def test_ner(caplog):
         {"text": "Schartau sagte dem Tagesspiegel, dass Fischer ein Idiot sei"},
     ]
     model = Inferencer.load(save_dir)
-    result = model.run_inference(dicts=basic_texts)
+    result = model.inference_from_dicts(dicts=basic_texts)
     assert result[0]["predictions"][0]["context"] == "sagte"
     assert isinstance(result[0]["predictions"][0]["probability"], np.float32)
 

--- a/test/test_processor_saving_loading.py
+++ b/test/test_processor_saving_loading.py
@@ -24,14 +24,14 @@ def test_processor_saving_loading(caplog):
                                             label_list=["OTHER", "OFFENSE"],
                                             metrics=["f1_macro"]
                                             )
-    dicts = processor._file_to_dicts(file="samples/doc_class/train-sample.tsv")
+    dicts = processor.file_to_dicts(file="samples/doc_class/train-sample.tsv")
     data, tensor_names = processor.dataset_from_dicts(dicts)
 
     save_dir = "testsave/processor"
     processor.save(save_dir)
 
     processor = processor.load_from_dir(save_dir)
-    dicts = processor._file_to_dicts(file="samples/doc_class/train-sample.tsv")
+    dicts = processor.file_to_dicts(file="samples/doc_class/train-sample.tsv")
     data_loaded, tensor_names_loaded = processor.dataset_from_dicts(dicts)
 
     assert tensor_names == tensor_names_loaded

--- a/test/test_question_answering.py
+++ b/test/test_question_answering.py
@@ -78,7 +78,7 @@ def test_qa(caplog):
     ]
 
     model = Inferencer.load(save_dir)
-    result = model.run_inference(dicts=QA_input)
+    result = model.inference_from_dicts(dicts=QA_input)
     assert isinstance(result[0]["predictions"][0]["end"],int)
 
 if(__name__=="__main__"):


### PR DESCRIPTION
The current `Inferencer` only supports running inference from dicts. 

This PR adds a new method `inference_from_file()` that takes a file as an input and uses multiprocessing to do speed-up inference preprocessing.

Additionally, the `_file_to_dicts()` in the `Processor` is made public.