### PR TITLE
Automatic multiprocessing chunksize

### DIFF
--- a/farm/__init__.py
+++ b/farm/__init__.py
@@ -15,4 +15,5 @@ if "file_descriptor" in mp.get_all_sharing_strategies():
     mp.set_sharing_strategy("file_descriptor")
 
     rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (10_000, rlimit[1]))
+    # seting soft limit to hard limit (=rlimit[1]) minus a small amount to be safe
+    resource.setrlimit(resource.RLIMIT_NOFILE, (rlimit[1]-512, rlimit[1]))

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -171,20 +171,15 @@ class DataSilo:
         }
 
     def _create_dev_from_train(self):
-        # TODO checks to ensure dev is loaded the right way
         n_dev = int(self.processor.dev_split * len(self.data["train"]))
         n_train = len(self.data["train"]) - n_dev
 
-        # Todo: Seed
-        # if(isinstance(self.data["train"], Dataset)):
-        #     train_dataset, dev_dataset = random_split(self.data["train"], [n_train, n_dev])
-        # else:
         train_dataset, dev_dataset = self.random_split_ConcatDataset(self.data["train"], lengths=[n_train, n_dev])
         self.data["train"] = train_dataset
         if(len(dev_dataset) > 0):
             self.data["dev"] = dev_dataset
         else:
-            logger.warning("No dev set created. Maybe adjust the dev_split parameter or the multiprocessing chunk size")
+            logger.warning("No dev set created. Please adjust the dev_split parameter.")
 
         logger.info(
             f"Took {len(dev_dataset)} samples out of train set to create dev set (dev split is roughly {self.processor.dev_split})"
@@ -203,6 +198,8 @@ class DataSilo:
             raise ValueError("Sum of input lengths does not equal the length of the input dataset!")
 
         idx_dataset = np.where(np.array(ds.cumulative_sizes) > lengths[0])[0][0]
+        assert idx_dataset >= 1, "Dev_split ratio is too large, there is no data in train set. " \
+                             f"Please lower dev_split = {self.processor.dev_split}"
 
         train = ConcatDataset(ds.datasets[:idx_dataset])
         test = ConcatDataset(ds.datasets[idx_dataset:])

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -29,7 +29,7 @@ class DataSilo:
     calculate and display some statistics.
      """
 
-    def __init__(self, processor, batch_size, distributed=False, multiprocessing_chunk_size=100):
+    def __init__(self, processor, batch_size, distributed=False):
         """
         :param processor: A dataset specific Processor object which will turn input (file or dict) into a Pytorch Dataset.
         :type processor: Processor
@@ -44,7 +44,6 @@ class DataSilo:
         self.data = {}
         self.batch_size = batch_size
         self.class_weights = None
-        self.multiprocessing_chunk_size = multiprocessing_chunk_size
         self.max_processes = 128
         self._load_data()
 
@@ -63,20 +62,28 @@ class DataSilo:
                 if self.processor.dev_split > 0.0:
                     random.shuffle(dicts)
 
-        dict_batches_to_process = int(len(dicts) / self.multiprocessing_chunk_size)
-        num_cpus = min(mp.cpu_count(), self.max_processes,  dict_batches_to_process) or 1
+        num_cpus = min(mp.cpu_count(), self.max_processes) or 1
+        dicts_per_cpu = np.ceil(len(dicts) / num_cpus)
+        # automatic adjustment of multiprocessing chunksize
+        # for small files (containing few dicts) we want small chunksize to ulitize all available cores but never less
+        # than 2, because we need it to sample another random sentence in LM finetuning
+        # for large files we want to minimize processor spawning without giving too much data to one process, so we
+        # clip it at 5k
+        multiprocessing_chunk_size = int(np.clip((np.ceil(dicts_per_cpu/5)),a_min=2,a_max=5000))
+        dict_batches_to_process = int(len(dicts) / multiprocessing_chunk_size)
+        num_cpus_used = min(mp.cpu_count(), self.max_processes,  dict_batches_to_process) or 1
 
         with ExitStack() as stack:
-            p = stack.enter_context(mp.Pool(processes=num_cpus))
+            p = stack.enter_context(mp.Pool(processes=num_cpus_used))
 
             logger.info(
-                f"Got ya {num_cpus} parallel workers to convert dict chunks to datasets (chunksize = {self.multiprocessing_chunk_size})..."
+                f"Got ya {num_cpus_used} parallel workers to convert dict chunks to datasets (chunksize = {multiprocessing_chunk_size})..."
             )
-            log_ascii_workers(num_cpus, logger)
+            log_ascii_workers(num_cpus_used, logger)
 
             results = p.imap(
                 partial(self._multiproc, processor=self.processor),
-                grouper(dicts, self.multiprocessing_chunk_size),
+                grouper(dicts, multiprocessing_chunk_size),
                 chunksize=1,
             )
 
@@ -84,7 +91,7 @@ class DataSilo:
             with tqdm(total=len(dicts), unit=' Dicts') as pbar:
                 for dataset, tensor_names in results:
                     datasets.append(dataset)
-                    pbar.update(self.multiprocessing_chunk_size)
+                    pbar.update(multiprocessing_chunk_size)
             
             concat_datasets = ConcatDataset(datasets)
             return concat_datasets, tensor_names

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -622,6 +622,7 @@ class BertStyleLMProcessor(Processor):
         return dicts
 
     def _dict_to_samples(self, dictionary, all_dicts=None):
+        assert len(all_dicts) > 1, "Need at least 2 documents to sample random sentences from"
         doc = dictionary["doc"]
         samples = []
         for idx in range(len(doc) - 1):

--- a/farm/eval.py
+++ b/farm/eval.py
@@ -90,6 +90,7 @@ class Evaluator:
                 # converting from string preds back to multi-hot encoding
                 from sklearn.preprocessing import MultiLabelBinarizer
                 mlb = MultiLabelBinarizer(classes=head.label_list)
+                # TODO check why .fit() should be called on predictions, rather than on labels
                 preds_all[head_num] = mlb.fit_transform(preds_all[head_num])
                 label_all[head_num] = mlb.transform(label_all[head_num])
 

--- a/farm/eval.py
+++ b/farm/eval.py
@@ -114,11 +114,7 @@ class Evaluator:
                     raise NotImplementedError
 
                 # CHANGE PARAMETERS, not all report_fn accept digits
-                if head.ph_output_type == "per_sequence_continuous":
-                    result["report"] = report_fn(
-                        label_all[head_num], preds_all[head_num]
-                    )
-                elif head.ph_output_type == "per_token":
+                if head.ph_output_type in ["per_sequence_continuous","per_token"]:
                     result["report"] = report_fn(
                         label_all[head_num], preds_all[head_num]
                     )
@@ -129,6 +125,7 @@ class Evaluator:
                         label_all[head_num],
                         preds_all[head_num],
                         digits=4,
+                        labels=head.label_list,
                         target_names=head.label_list)
 
             all_results.append(result)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -2,6 +2,7 @@ import os
 import torch
 import logging
 import multiprocessing as mp
+import numpy as np
 from contextlib import ExitStack
 from functools import partial
 
@@ -48,8 +49,7 @@ class Inferencer:
         batch_size=4,
         gpu=False,
         name=None,
-        return_class_probs=False,
-        multiprocessing_chunk_size=100,
+        return_class_probs=False
     ):
         """
         Initializes Inferencer from an AdaptiveModel and a Processor instance.
@@ -88,7 +88,6 @@ class Inferencer:
         #     raise NotImplementedError("A model with multiple prediction heads is currently not supported by the Inferencer")
         self.name = name if name != None else f"anonymous-{self.prediction_type}"
         self.return_class_probs = return_class_probs
-        self.multiprocessing_chunk_size = multiprocessing_chunk_size
 
         model.connect_heads_with_processor(processor.tasks, require_labels=False)
         set_all_seeds(42, n_gpu)
@@ -101,7 +100,6 @@ class Inferencer:
         gpu=False,
         embedder_only=False,
         return_class_probs=False,
-        multiprocessing_chunk_size=100,
     ):
         """
         Initializes Inferencer from directory with saved model.
@@ -115,8 +113,6 @@ class Inferencer:
         :param embedder_only: If true, a faster processor (InferenceProcessor) is loaded. This should only be used
         for extracting embeddings (no downstream predictions).
         :type embedder_only: bool
-        :param multiprocessing_chunk_size: chunksize param for Python Multiprocessing imap().
-        :type multiprocessing_chunk_size: int
         :return: An instance of the Inferencer.
         """
 
@@ -137,7 +133,6 @@ class Inferencer:
             gpu=gpu,
             name=name,
             return_class_probs=return_class_probs,
-            multiprocessing_chunk_size=multiprocessing_chunk_size,
         )
 
     def inference_from_file(self, file):
@@ -164,20 +159,28 @@ class Inferencer:
                 f"b) ... run inference on a downstream task: make sure your model path {self.name} contains a saved prediction head"
             )
 
-        dict_batches_to_process = int(len(dicts) / self.multiprocessing_chunk_size)
-        num_cpus = min(mp.cpu_count(), dict_batches_to_process) or 1
+        num_cpus = mp.cpu_count() or 1
+        dicts_per_cpu = np.ceil(len(dicts) / num_cpus)
+        # automatic adjustment of multiprocessing chunksize
+        # for small files (containing few dicts) we want small chunksize to ulitize all available cores but never less
+        # than 2, because we need it to sample another random sentence in LM finetuning
+        # for large files we want to minimize processor spawning without giving too much data to one process, so we
+        # clip it at 5k
+        multiprocessing_chunk_size = int(np.clip((np.ceil(dicts_per_cpu / 5)), a_min=2, a_max=5000))
+        dict_batches_to_process = int(len(dicts) / multiprocessing_chunk_size)
+        num_cpus_used = min(mp.cpu_count(), dict_batches_to_process) or 1
 
         with ExitStack() as stack:
-            p = stack.enter_context(mp.Pool(processes=num_cpus))
+            p = stack.enter_context(mp.Pool(processes=num_cpus_used))
 
             logger.info(
-                f"Got ya {num_cpus} parallel workers to do inference on {len(dicts)}dicts (chunksize = {self.multiprocessing_chunk_size})..."
+                f"Got ya {num_cpus_used} parallel workers to do inference on {len(dicts)}dicts (chunksize = {multiprocessing_chunk_size})..."
             )
-            log_ascii_workers(num_cpus, logger)
+            log_ascii_workers(num_cpus_used, logger)
 
             results = p.imap(
                 partial(self._multiproc, processor=self.processor, rest_api_schema=rest_api_schema),
-                grouper(dicts, self.multiprocessing_chunk_size),
+                grouper(dicts, multiprocessing_chunk_size),
                 1,
             )
 
@@ -185,7 +188,7 @@ class Inferencer:
             with tqdm(total=len(dicts), unit=" Dicts") as pbar:
                 for dataset, tensor_names, sample in results:
                     preds_all.extend(self._run_inference(dataset, tensor_names, sample))
-                    pbar.update(self.multiprocessing_chunk_size)
+                    pbar.update(multiprocessing_chunk_size)
 
         return preds_all
 


### PR DESCRIPTION
This parameter creates a lot of problems:
When set too low it spawns processes faster than the master process can handle
When set too high it might lead to OOM issues

This PR sets this parameter automatically, based on number of cpus available and the data set size.
This PR solves #113 

Please test if this solves processing issues with very large datasets @brandenchan without the need to set the mutliproc chunksize parameter.