### PR TITLE
Fix name of squad labels in experiment config

### DIFF
--- a/experiments/qa/squad20_config.json
+++ b/experiments/qa/squad20_config.json
@@ -4,7 +4,7 @@
     "data_dir":   {"value": null, "default": "data/squad20", "desc": "Input directory for downstream task. For SQuAD the test set is private. You need to submit models that are then evaluated."},
     "output_dir": {"value": null, "default": "saved_models", "desc": "Output directory where model predictions and checkpoints will be saved."},
 
-    "cuda":        {"value": null, "default": true,  "desc": "CUDA flag,  uses CUDA if available."},
+    "cuda":        {"value": null, "default": false,  "desc": "CUDA flag,  uses CUDA if available."},
     "local_rank":  {"value": null, "default": -1,    "desc": "If local_rank == -1 -> multiGPU mode on one machine,  other values signal distributed computation across several nodes (apex install required)."},
     "fp16":        {"value": null, "default": false, "desc": "Floating point precision. IF true it halves the precision and therefore the memory requirements,  so you can doulbe the batch size."},
     "loss_scale":  {"value": null, "default": 0,     "desc": "Loss scaling to improve fp16 numeric stability. Only used when fp16 set to True. 0 (default value): dynamic loss scaling. Positive power of 2: static loss scaling value."},
@@ -26,7 +26,7 @@
     "train_filename":   {"value": null, "default": "train-v2.0.json",      "desc": "Filename for training."},
     "dev_filename":     {"value": null, "default": "dev-v2.0.json",        "desc": "Filename for development. Contains multiple possible answers."},
     "test_filename":    {"value": null, "default": null,       "desc": "Filename for testing. It is the submission file from competition."},
-    "label_list":           {"value": null, "default": ["start_token", "end_token"], "desc": ""},
+    "labels":           {"value": null, "default": ["start_token", "end_token"], "desc": ""},
     "metric":          {"value": null, "default": "squad",       "desc": "Metric used. A f1 scored tailored to sequences of labels."}
   },
 

--- a/experiments/qa/squad20_config.json
+++ b/experiments/qa/squad20_config.json
@@ -4,7 +4,7 @@
     "data_dir":   {"value": null, "default": "data/squad20", "desc": "Input directory for downstream task. For SQuAD the test set is private. You need to submit models that are then evaluated."},
     "output_dir": {"value": null, "default": "saved_models", "desc": "Output directory where model predictions and checkpoints will be saved."},
 
-    "cuda":        {"value": null, "default": false,  "desc": "CUDA flag,  uses CUDA if available."},
+    "cuda":        {"value": null, "default": true,  "desc": "CUDA flag,  uses CUDA if available."},
     "local_rank":  {"value": null, "default": -1,    "desc": "If local_rank == -1 -> multiGPU mode on one machine,  other values signal distributed computation across several nodes (apex install required)."},
     "fp16":        {"value": null, "default": false, "desc": "Floating point precision. IF true it halves the precision and therefore the memory requirements,  so you can doulbe the batch size."},
     "loss_scale":  {"value": null, "default": 0,     "desc": "Loss scaling to improve fp16 numeric stability. Only used when fp16 set to True. 0 (default value): dynamic loss scaling. Positive power of 2: static loss scaling value."},

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -406,6 +406,9 @@ class TextClassificationProcessor(Processor):
                           label_list=label_list,
                           label_column_name=label_column_name,
                           task_type=task_type)
+        else:
+            logger.info("Initialized processor without tasks. Supply `metric` and `label_list` to the constructor for "
+                        "using the default task or add a custom task later via processor.add_task()")
 
     def file_to_dicts(self, file: str) -> [dict]:
         column_mapping = {task["label_column_name"]: task["label_name"] for task in self.tasks.values()}
@@ -554,6 +557,9 @@ class NERProcessor(Processor):
 
         if metric and label_list:
             self.add_task("ner", metric, label_list)
+        else:
+            logger.info("Initialized processor without tasks. Supply `metric` and `label_list` to the constructor for "
+                        "using the default task or add a custom task later via processor.add_task()")
 
     def file_to_dicts(self, file: str) -> [dict]:
         dicts = read_ner_file(filename=file, sep=self.delimiter)
@@ -717,6 +723,9 @@ class SquadProcessor(Processor):
 
         if metric and labels:
             self.add_task("question_answering", metric, labels)
+        else:
+            logger.info("Initialized processor without tasks. Supply `metric` and `label_list` to the constructor for "
+                        "using the default task or add a custom task later via processor.add_task()")
 
     def dataset_from_dicts(self, dicts, index=None, rest_api_schema=False):
         if rest_api_schema:


### PR DESCRIPTION
This adresses issue #120 

The name was not updated yet from the deprecated "label_list" to "labels". 
This lead to initializing a processor without any tasks. Therefore the connection with the prediction head failed.

I have added now also a info message to inform for such cases, where labels or metric are not provided to the processor. 