### PR TITLE
Dataset from dicts

### DIFF
--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -72,17 +72,19 @@ class DataSilo:
         dataset = processor.dataset_from_dicts(dicts=dicts, index=index)
         return dataset
 
-    def _get_dataset(self, filename=None, dicts=None):
+    def _get_dataset(self, filename, dicts=None):
         if not filename and not dicts:
             raise ValueError("You must either supply `filename` or `dicts`")
 
+        # loading dicts from file (default)
         if dicts is None:
             dicts = self.processor.file_to_dicts(filename)
-        #shuffle list of dicts here if we later want to have a random dev set splitted from train set
-        if self.processor.train_filename in filename:
-            if not self.processor.dev_filename:
-                if self.processor.dev_split > 0.0:
-                    random.shuffle(dicts)
+            #shuffle list of dicts here if we later want to have a random dev set splitted from train set
+            if self.processor.train_filename in filename:
+                if not self.processor.dev_filename:
+                    if self.processor.dev_split > 0.0:
+                        random.shuffle(dicts)
+
         num_dicts = len(dicts)
         multiprocessing_chunk_size, num_cpus_used = calc_chunksize(num_dicts)
 


### PR DESCRIPTION
As requested in #85, we can add an option to let the DataSilo load data from dicts instead of automatic loading from files. 

Exemplary Usage: 
``` 
processor = TextClassificationProcessor(tokenizer=tokenizer,
                                        max_seq_len=8,
                                        data_dir=None,
                                        train_filename=None,
                                        label_list=["OTHER", "OFFENSE"],
                                        metric="f1_macro",
                                        dev_filename=None,
                                        test_filename=None,
                                        dev_split=0.0,
                                        label_column_name=None)

data_silo = DataSilo(
    processor=processor,
    batch_size=batch_size,
    automatic_loading=False)

basic_texts = [
    {"text": "Martin Müller spielt Handball in Berlin.", "text_classification_label": "OTHER"},
    {"text": "Schartau sagte dem Tagesspiegel, dass Fischer ein Idiot sei.", "text_classification_label": "OFFENSE"}
]
data_silo._load_data(train_dicts=basic_texts)
``` 