### PR TITLE
Add option to disable multiprocessing in Inferencer(#117)

### DIFF
--- a/farm/inference_rest_api.py
+++ b/farm/inference_rest_api.py
@@ -79,7 +79,7 @@ class InferenceEndpoint(Resource):
         dicts = request.get_json().get("input", None)
         if not dicts:
             return {}
-        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True)
+        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True, use_multiprocessing=False)
         return results[0]
 
 


### PR DESCRIPTION
The time incurred in spawning processes could outweigh performance boost for very small number of dicts, eg, HTTP APIs for inference. A new param `use_multiprocessing` allows to disable multiprocessing for such use cases.