### PR TITLE
Raise an Exception when an invalid path is supplied for loading a saved model 

### DIFF
--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -92,8 +92,15 @@ class LanguageModel(nn.Module):
                 language_model = cls.subclasses["Bert"].load(pretrained_model_name_or_path, **kwargs)
             elif 'xlnet' in pretrained_model_name_or_path:
                 language_model = cls.subclasses["XLNet"].load(pretrained_model_name_or_path, **kwargs)
+            else:
+                language_model = None
 
-        assert language_model is not None
+        if not language_model:
+            raise Exception(
+                f"Model not found for {pretrained_model_name_or_path}. Either supply the local path for a saved model "
+                f"or one of bert/roberta/xlnet models that can be downloaded from remote. Here's the list of available "
+                f"models: https://farm.deepset.ai/api/modeling.html#farm.modeling.language_model.LanguageModel.load"
+            )
 
         return language_model
 


### PR DESCRIPTION
When loading a saved model, if the given local path doesn't contain a model the `language_model` is uninitialized. This leads to an `UnboundLocalError` when `assert language_model is not None` gets executed, making the error stack cryptic.

This PR add a condition to check if the model is loaded and raises an exception with helpful message if otherwise.