### PR TITLE
Fix loading custom vocab in transformers style for LM finetuning

### DIFF
--- a/farm/data_handler/input_features.py
+++ b/farm/data_handler/input_features.py
@@ -233,8 +233,8 @@ def samples_to_features_bert_lm(sample, max_seq_len, tokenizer, next_sent_pred=T
         tokens_b, t2_label = mask_random_words(tokens_b, tokenizer.vocab,
                                                token_groups=sample.tokenized["text_b"]["start_of_word"])
         # convert lm labels to ids
-        t1_label_ids = [-1 if tok == '' else tokenizer.vocab[tok] for tok in t1_label]
-        t2_label_ids = [-1 if tok == '' else tokenizer.vocab[tok] for tok in t2_label]
+        t1_label_ids = [-1 if tok == '' else tokenizer.convert_tokens_to_ids(tok) for tok in t1_label]
+        t2_label_ids = [-1 if tok == '' else tokenizer.convert_tokens_to_ids(tok) for tok in t2_label]
         lm_label_ids = t1_label_ids + t2_label_ids
 
         # Convert is_next_label: Note that in Bert, is_next_labelid = 0 is used for next_sentence=true!
@@ -248,7 +248,7 @@ def samples_to_features_bert_lm(sample, max_seq_len, tokenizer, next_sent_pred=T
         tokens_a, t1_label = mask_random_words(tokens_a, tokenizer.vocab,
                                                token_groups=sample.tokenized["text_a"]["start_of_word"])
         # convert lm labels to ids
-        lm_label_ids = [-1 if tok == '' else tokenizer.vocab[tok] for tok in t1_label]
+        lm_label_ids = [-1 if tok == '' else tokenizer.convert_tokens_to_ids(tok) for tok in t1_label]
 
     # encode string tokens to input_ids and add special tokens
     inputs = tokenizer.encode_plus(text=tokens_a,

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -349,6 +349,7 @@ def mask_random_words(tokens, vocab, token_groups=None, max_predictions_per_seq=
                 tokens[index] = "[MASK]"
 
             # 10% randomly change token to random token
+            #TODO currently custom vocab is not included here
             elif prob < 0.9:
                 tokens[index] = random.choice(list(vocab.items()))[0]
 

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -109,7 +109,7 @@ class LanguageModel(nn.Module):
             model_emb_size = language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
             vocab_size = model_emb_size + n_added_tokens
             logger.info(
-                f"Tokenizer vocabulary (len: {vocab_size}) does not match original language model vocabulary (len: {model_emb_size}). Resizing embedding layer of LM accordingly")
+                f"Resizing embedding layer of LM from {model_emb_size} to {vocab_size} to cope for custom vocab.")
             language_model.model.resize_token_embeddings(vocab_size)
             # verify
             model_emb_size = language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -54,7 +54,7 @@ class LanguageModel(nn.Module):
         raise NotImplementedError
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, **kwargs):
+    def load(cls, pretrained_model_name_or_path, n_added_tokens=0, **kwargs):
         """
         Load a pretrained language model either by
 
@@ -102,6 +102,18 @@ class LanguageModel(nn.Module):
                 f"or one of bert/roberta/xlnet models that can be downloaded from remote. Here's the list of available "
                 f"models: https://farm.deepset.ai/api/modeling.html#farm.modeling.language_model.LanguageModel.load"
             )
+
+        # resize embeddings in case of custom vocab
+        if n_added_tokens != 0:
+            # TODO verify for other models than BERT
+            model_emb_size = language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+            vocab_size = model_emb_size + n_added_tokens
+            logger.info(
+                f"Tokenizer vocabulary (len: {vocab_size}) does not match original language model vocabulary (len: {model_emb_size}). Resizing embedding layer of LM accordingly")
+            language_model.model.resize_token_embeddings(vocab_size)
+            # verify
+            model_emb_size = language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+            assert vocab_size == model_emb_size
 
         return language_model
 

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -107,7 +107,7 @@ class PredictionHead(nn.Module):
         prediction_head = cls.subclasses[config["name"]](**config)
         model_file = cls._get_model_file(config_file=config_file)
         logger.info("Loading prediction head from {}".format(model_file))
-        prediction_head.load_state_dict(torch.load(model_file, map_location=torch.device("cpu")), strict=False)
+        prediction_head.load_state_dict(torch.load(model_file, map_location=torch.device("cpu")))
         return prediction_head
 
     def logits_to_loss(self, logits, labels):

--- a/farm/train.py
+++ b/farm/train.py
@@ -129,7 +129,7 @@ class Trainer:
         model.connect_heads_with_processor(self.data_silo.processor.tasks, require_labels=True)
 
         # Check that the tokenizer fits the language model
-        self.check_tokenizer_lm(self.data_silo.processor.tokenizer, model.language_model)
+        model.verify_vocab_size(vocab_size=len(self.data_silo.processor.tokenizer))
 
         logger.info(f"\n {GROWING_TREE}")
         model.train()
@@ -200,17 +200,6 @@ class Trainer:
         if self.grad_acc_steps > 1:
             loss = loss / self.grad_acc_steps
         return loss
-
-    def check_tokenizer_lm(self, tokenizer, lm):
-        tok_vocab_len = len(tokenizer)
-        #TODO make this generic for other models
-        model_vocab_len = lm.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
-        #model_vocab_len = lm.model.embeddings.word_embeddings.num_embeddings
-        if tok_vocab_len != model_vocab_len:
-            f"Tokenizer vocabulary (len: {tok_vocab_len}) does not match original language model vocabulary (len: {model_vocab_len}). Resizing embedding layer of LM accordingly"
-            lm.model.resize_token_embeddings(len(tokenizer))
-            model_vocab_len = lm.model.embeddings.word_embeddings.num_embeddings
-        assert tok_vocab_len == model_vocab_len
 
     def log_params(self):
         params = {"epochs": self.epochs, "n_gpu": self.n_gpu, "device": self.device}

--- a/test/samples/lm_finetuning/train-sample.txt
+++ b/test/samples/lm_finetuning/train-sample.txt
@@ -2,6 +2,10 @@ Text should be one-sentence-per-line, with empty lines between documents.
 A Seentence to teest whoole woord maasking, muust includio multiplee woords wiith subwoord tookens.
 This text is included to make sure Unicode is handled properly: 力加勝北区ᴵᴺᵀᵃছজটডণত
 
+aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ccccccccccccccccccccccc
+aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccc
+aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ccccccccccccccccccccccc
+
 The rain had only ceased with the gray streaks of morning at Blazing Star, and the settlement awoke to a moral sense of cleanliness, and the finding of forgotten knives, tin cups, and smaller camp utensils, where the heavy showers had washed away the debris and dust heaps before the cabin doors.
 Indeed, it was recorded in Blazing Star that a fortunate early riser had once picked up on the highway a solid chunk of gold quartz which the rain had freed from its incumbering soil, and washed into immediate and glittering popularity.
 Possibly this may have been the reason why early risers in that locality, during the rainy season, adopted a thoughtful habit of body, and seldom lifted their eyes to the rifted or india-ink washed skies above them.

--- a/test/test_lm_finetuning.py
+++ b/test/test_lm_finetuning.py
@@ -1,5 +1,6 @@
 import logging
 import numpy as np
+import torch
 
 from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import BertStyleLMProcessor
@@ -68,6 +69,10 @@ def test_lm_finetuning(caplog):
     )
 
     model = trainer.train(model)
+
+    # LM embeddings and weight of decoder in head are shared and should therefore be equal
+    assert torch.all(
+        torch.eq(model.language_model.model.embeddings.word_embeddings.weight, model.prediction_heads[0].decoder.weight))
 
     save_dir = "testsave/lm_finetuning"
     model.save(save_dir)
@@ -141,7 +146,89 @@ def test_lm_finetuning_no_next_sentence(caplog):
 
     model = trainer.train(model)
 
+    # LM embeddings and weight of decoder in head are shared and should therefore be equal
+    assert torch.all(
+        torch.eq(model.language_model.model.embeddings.word_embeddings.weight, model.prediction_heads[0].decoder.weight))
+
     save_dir = "testsave/lm_finetuning_no_nsp"
+    model.save(save_dir)
+    processor.save(save_dir)
+
+    basic_texts = [
+        {"text": "Farmer's life is great."},
+        {"text": "It's nothing for big city kids though."},
+    ]
+    model = Inferencer.load(save_dir, embedder_only=True)
+    result = model.extract_vectors(dicts=basic_texts)
+    assert result[0]["context"] == ['Farmer', "'", 's', 'life', 'is', 'great', '.']
+    assert result[0]["vec"].shape == (768,)
+    # TODO check why results vary accross runs with same seed
+    assert isinstance(result[0]["vec"][0], np.float32)
+
+
+def test_lm_finetuning_custom_vocab(caplog):
+    caplog.set_level(logging.CRITICAL)
+
+    set_all_seeds(seed=42)
+    device, n_gpu = initialize_device_settings(use_cuda=False)
+    n_epochs = 1
+    batch_size = 1
+    evaluate_every = 2
+    lang_model = "bert-base-cased"
+
+    tokenizer = Tokenizer.load(
+        pretrained_model_name_or_path=lang_model, do_lower_case=False
+    )
+    tokenizer.add_tokens(["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbb", "ccccccccccccccccccccccc"])
+
+    processor = BertStyleLMProcessor(
+        data_dir="samples/lm_finetuning",
+        train_filename="train-sample.txt",
+        test_filename="test-sample.txt",
+        dev_filename=None,
+        tokenizer=tokenizer,
+        max_seq_len=12,
+        next_sent_pred=True
+    )
+    data_silo = DataSilo(processor=processor, batch_size=batch_size)
+
+    language_model = LanguageModel.load(lang_model, n_added_tokens=len(tokenizer.added_tokens_decoder))
+    lm_prediction_head = BertLMHead.load(lang_model, n_added_tokens=len(tokenizer.added_tokens_decoder))
+    next_sentence_head = NextSentenceHead.load(lang_model)
+
+    model = AdaptiveModel(
+        language_model=language_model,
+        prediction_heads=[lm_prediction_head, next_sentence_head],
+        embeds_dropout_prob=0.1,
+        lm_output_types=["per_token", "per_sequence"],
+        device=device
+    )
+
+    optimizer, warmup_linear = initialize_optimizer(
+        model=model,
+        learning_rate=2e-5,
+        warmup_proportion=0.1,
+        n_batches=len(data_silo.loaders["train"]),
+        n_epochs=n_epochs,
+    )
+
+    trainer = Trainer(
+        optimizer=optimizer,
+        data_silo=data_silo,
+        epochs=n_epochs,
+        n_gpu=n_gpu,
+        warmup_linear=warmup_linear,
+        evaluate_every=evaluate_every,
+        device=device,
+    )
+
+    model = trainer.train(model)
+
+    # LM embeddings and weight of decoder in head are shared and should therefore be equal
+    assert torch.all(
+        torch.eq(model.language_model.model.embeddings.word_embeddings.weight, model.prediction_heads[0].decoder.weight))
+
+    save_dir = "testsave/lm_finetuning"
     model.save(save_dir)
     processor.save(save_dir)
 


### PR DESCRIPTION
LM finetuning with custom vocab was broken after switching to the transformer style of handling custom vocab (adding tokens instead of using "unused tokens"). 

The complication here is that with a larger vocab we need to adjust both the size of the embedding layer in the LM and the decoder (bias+weights) in the PH. In addition, the decoder shares the weights with the embedding layer.  

We therefore need to supply now an extra arg "n_added_tokens" for loading the PH / LM. 

Example: 
```
    ...
    tokenizer.add_tokens(["somecustomtoken", "specialrareword"])

    ...
    language_model = LanguageModel.load(lang_model, n_added_tokens=len(tokenizer.added_tokens_decoder))
    lm_prediction_head = BertLMHead.load(lang_model, n_added_tokens=len(tokenizer.added_tokens_decoder))
```
