### PR TITLE
fix duplicate samples in LM finetuning

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -641,7 +641,7 @@ class BertStyleLMProcessor(Processor):
                         seq_b=tokenized["text_b"][seq_name],
                         tokenizer=self.tokenizer,
                         max_seq_len=self.max_seq_len)
-                    samples.append(Sample(id=None, clear_text=sample_in_clear_text, tokenized=tokenized))
+                samples.append(Sample(id=None, clear_text=sample_in_clear_text, tokenized=tokenized))
             # if we don't do next sentence prediction, we should feed in a single sentence
             else:
                 text_a = doc[idx]
@@ -661,7 +661,7 @@ class BertStyleLMProcessor(Processor):
                         seq_b=None,
                         tokenizer=self.tokenizer,
                         max_seq_len=self.max_seq_len)
-                    samples.append(Sample(id=None, clear_text=sample_in_clear_text, tokenized=tokenized))
+                samples.append(Sample(id=None, clear_text=sample_in_clear_text, tokenized=tokenized))
         return samples
 
     def _sample_to_features(self, sample) -> dict:

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -330,6 +330,7 @@ def mask_random_words(tokens, vocab, token_groups=None, max_predictions_per_seq=
     random.shuffle(cand_indices)
     output_label = [''] * len(tokens)
     num_masked = 0
+    assert "[MASK]" not in tokens
 
     # 2. Mask the first groups until we reach the number of tokens we wanted to mask (num_to_mask)
     for index_set in cand_indices:


### PR DESCRIPTION
Due to a wrong indentation we created three copies of one sample.

This not only blew up the dataset but also caused another problem: In featurization when we mask words, we manipulated the same object multiple times leading to additional masked input tokens with no counter part on the label side. 