### PR TITLE
Add backwards compatibility for loading prediction head

### DIFF
--- a/farm/infer.py
+++ b/farm/infer.py
@@ -96,6 +96,7 @@ class Inferencer:
         gpu=False,
         embedder_only=False,
         return_class_probs=False,
+        strict=True
     ):
         """
         Initializes Inferencer from directory with saved model.
@@ -108,13 +109,17 @@ class Inferencer:
         :type gpu: bool
         :param embedder_only: If true, a faster processor (InferenceProcessor) is loaded. This should only be used for extracting embeddings (no downstream predictions).
         :type embedder_only: bool
+        :param strict: whether to strictly enforce that the keys loaded from saved model match the ones in
+                       the PredictionHead (see torch.nn.module.load_state_dict()).
+                       Set to `False` for backwards compatibility with PHs saved with older version of FARM.
+        :type strict: bool
         :return: An instance of the Inferencer.
 
         """
 
         device, n_gpu = initialize_device_settings(use_cuda=gpu, local_rank=-1, fp16=False)
 
-        model = AdaptiveModel.load(load_dir, device)
+        model = AdaptiveModel.load(load_dir, device, strict=strict)
         if embedder_only:
             # model.prediction_heads = []
             processor = InferenceProcessor.load_from_dir(load_dir)

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -68,7 +68,7 @@ class AdaptiveModel(nn.Module):
             # Need to save config and pipeline
 
     @classmethod
-    def load(cls, load_dir, device):
+    def load(cls, load_dir, device, strict=True):
         """
         Loads an AdaptiveModel from a directory. The directory must contain:
 
@@ -83,6 +83,10 @@ class AdaptiveModel(nn.Module):
         :type load_dir: str
         :param device: to which device we want to sent the model, either cpu or cuda
         :type device: torch.device
+        :param strict: whether to strictly enforce that the keys loaded from saved model match the ones in
+                       the PredictionHead (see torch.nn.module.load_state_dict()).
+                       Set to `False` for backwards compatibility with PHs saved with older version of FARM.
+        :type strict: bool
         """
 
         # Language Model
@@ -93,7 +97,7 @@ class AdaptiveModel(nn.Module):
         prediction_heads = []
         ph_output_type = []
         for config_file in ph_config_files:
-            head = PredictionHead.load(config_file)
+            head = PredictionHead.load(config_file, strict=strict)
             # # set shared weights between LM and PH
             # if type(head) == BertLMHead:
             #     head.set_shared_weights(language_model)

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -94,12 +94,16 @@ class PredictionHead(nn.Module):
         self.config = config
 
     @classmethod
-    def load(cls, config_file):
+    def load(cls, config_file, strict=True):
         """
         Loads a Prediction Head. Infers the class of prediction head from config_file.
 
         :param config_file: location where corresponding config is stored
         :type config_file: str
+        :param strict: whether to strictly enforce that the keys loaded from saved model match the ones in
+                       the PredictionHead (see torch.nn.module.load_state_dict()).
+                       Set to `False` for backwards compatibility with PHs saved with older version of FARM.
+        :type strict: bool
         :return: PredictionHead
         :rtype: PredictionHead[T]
         """
@@ -107,7 +111,7 @@ class PredictionHead(nn.Module):
         prediction_head = cls.subclasses[config["name"]](**config)
         model_file = cls._get_model_file(config_file=config_file)
         logger.info("Loading prediction head from {}".format(model_file))
-        prediction_head.load_state_dict(torch.load(model_file, map_location=torch.device("cpu")))
+        prediction_head.load_state_dict(torch.load(model_file, map_location=torch.device("cpu")), strict=strict)
         return prediction_head
 
     def logits_to_loss(self, logits, labels):


### PR DESCRIPTION
In older versions of FARM the TextClassificationHead had the parameter "balanced_weights"  which also got stored in the .bin. Loading these older models in the recent version of FARM gives: 

```

  File "../torch/nn/modules/module.py", line 839, in load_state_dict
    self.__class__.__name__, "\n\t".join(error_msgs)))
RuntimeError: Error(s) in loading state_dict for TextClassificationHead:
	Unexpected key(s) in state_dict: "balanced_weights". 
``` 
This is due to `torch.nn.module.load_state_dict()`, which has a `strict` flag that handles if a model can be loaded even though there are different keys. Let's allow changing this flag from FARM's load methods to allow backward compatibility.     