### PR TITLE
Add max_multiprocessing_chunksize as a param for DataSilo

### DIFF
--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -43,7 +43,7 @@ processor = BertStyleLMProcessor(
     data_dir="../data/lm_finetune_nips", tokenizer=tokenizer, max_seq_len=128, max_docs=30
 )
 # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
-data_silo = DataSilo(processor=processor, batch_size=batch_size)
+data_silo = DataSilo(processor=processor, batch_size=batch_size, max_multiprocessing_chunksize=20)
 
 # 4. Create an AdaptiveModel
 # a) which consists of a pretrained language model as a basis

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -39,6 +39,10 @@ class DataSilo:
         :type distributed: bool
         :param automatic_loading: Set to False, if you don't want to automatically load data at initialization.
         :type automatic_loading: bool
+        :param max_multiprocessing_chunksize: max possible value for chunksize as calculated by `calc_chunksize()`
+            in `farm.utils`. For certain cases like lm_finetuning, a smaller value can be set, as the default chunksize
+            values are rather large that might cause memory issues.
+        :type max_multiprocessing_chunksize: int
 
         """
         self.distributed = distributed

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -29,7 +29,7 @@ class DataSilo:
     calculate and display some statistics.
      """
 
-    def __init__(self, processor, batch_size, distributed=False, automatic_loading=True):
+    def __init__(self, processor, batch_size, distributed=False, automatic_loading=True, max_multiprocessing_chunksize=2000):
         """
         :param processor: A dataset specific Processor object which will turn input (file or dict) into a Pytorch Dataset.
         :type processor: Processor
@@ -47,6 +47,7 @@ class DataSilo:
         self.batch_size = batch_size
         self.class_weights = None
         self.max_processes = 128
+        self.max_multiprocessing_chunksize = max_multiprocessing_chunksize
         # In most cases we want to load all data automatically, but in some cases we rather want to do this later or
         # load from dicts instead of file (https://github.com/deepset-ai/FARM/issues/85)
         if automatic_loading:
@@ -86,7 +87,7 @@ class DataSilo:
                         random.shuffle(dicts)
 
         num_dicts = len(dicts)
-        multiprocessing_chunk_size, num_cpus_used = calc_chunksize(num_dicts)
+        multiprocessing_chunk_size, num_cpus_used = calc_chunksize(num_dicts, max_chunksize=self.max_multiprocessing_chunksize)
 
         with ExitStack() as stack:
             p = stack.enter_context(mp.Pool(processes=num_cpus_used))

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -21,9 +21,7 @@ def set_all_seeds(seed, n_gpu=0):
     if n_gpu > 0:
         torch.cuda.manual_seed_all(seed)
 
-def calc_chunksize(num_dicts):
-    MIN_CHUNKSIZE = 4
-    MAX_CHUNKSIZE = 2000
+def calc_chunksize(num_dicts, min_chunksize=4, max_chunksize=2000):
     num_cpus = mp.cpu_count() or 1
     dicts_per_cpu = np.ceil(num_dicts / num_cpus)
     # automatic adjustment of multiprocessing chunksize
@@ -31,7 +29,7 @@ def calc_chunksize(num_dicts):
     # than 2, because we need it to sample another random sentence in LM finetuning
     # for large files we want to minimize processor spawning without giving too much data to one process, so we
     # clip it at 5k
-    multiprocessing_chunk_size = int(np.clip((np.ceil(dicts_per_cpu / 5)), a_min=MIN_CHUNKSIZE, a_max=MAX_CHUNKSIZE))
+    multiprocessing_chunk_size = int(np.clip((np.ceil(dicts_per_cpu / 5)), a_min=min_chunksize, a_max=max_chunksize))
     dict_batches_to_process = int(num_dicts / multiprocessing_chunk_size)
     num_cpus_used = min(mp.cpu_count(), dict_batches_to_process) or 1
     return multiprocessing_chunk_size,num_cpus_used


### PR DESCRIPTION
The default mp chunksize value computed by `calc_chunksize()` for lm_finetuning task is rather large leading to memory issues. 

This PR introduces a `max_multiprocessing_chunksize` param for the `DataSilo`, enabling to have an upper limit for the chunksize.