### PR TITLE
Add train loss to tqdm. add desc for data preproc. log only 2 samples

### DIFF
--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -111,7 +111,7 @@ class DataSilo:
             )
 
             datasets = []
-            with tqdm(total=len(dicts), unit=' Dicts') as pbar:
+            with tqdm(total=len(dicts), unit=' Dicts', desc="Preprocessing Dataset") as pbar:
                 for dataset, tensor_names in results:
                     datasets.append(dataset)
                     pbar.update(multiprocessing_chunk_size)

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -863,7 +863,7 @@ class SquadProcessor(Processor):
         self._init_samples_in_baskets()
         self._featurize_samples()
         if index == 0:
-            self._log_samples(3)
+            self._log_samples(2)
         # This mode is for inference where we need to keep baskets
         if return_baskets:
             dataset, tensor_names = self._create_dataset(keep_baskets=True)


### PR DESCRIPTION
- Adding train loss (of current batch) to tqdm progress bar during training
- Adding descriptive text to progressbar in datasilo
- Log only 2 samples to make logs cleaner (instead of 3)