### PR TITLE
Implement next_sent_pred flag

### DIFF
--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -239,6 +239,19 @@ class AdaptiveModel(nn.Module):
         :param require_labels: If True, an error will be thrown when a task is not supplied with labels)
         :return:
         """
+
+        # Drop the next sentence prediction head if it does not appear in tasks. This is triggered by the interaction
+        # setting the argument BertStyleLMProcessor(next_sent_pred=False)
+        if "nextsentence" not in tasks:
+            idx = None
+            for i, ph in enumerate(self.prediction_heads):
+                if ph.task_name == "nextsentence":
+                    idx = i
+            if idx is None:
+                raise Exception
+            logger.info("Removing the NextSentenceHead since next_sent_pred is set to False in the BertStyleLMProcessor")
+            del self.prediction_heads[i]
+
         for head in self.prediction_heads:
             head.label_tensor_name = tasks[head.task_name]["label_tensor_name"]
             label_list = tasks[head.task_name]["label_list"]

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -247,10 +247,9 @@ class AdaptiveModel(nn.Module):
             for i, ph in enumerate(self.prediction_heads):
                 if ph.task_name == "nextsentence":
                     idx = i
-            if idx is None:
-                raise Exception
             logger.info("Removing the NextSentenceHead since next_sent_pred is set to False in the BertStyleLMProcessor")
-            del self.prediction_heads[i]
+            if idx is not None:
+                del self.prediction_heads[i]
 
         for head in self.prediction_heads:
             head.label_tensor_name = tasks[head.task_name]["label_tensor_name"]


### PR DESCRIPTION
Previously the next_sent_pred argument in the BertStyleLMProcessor was not working if the NextSentenceHead is passed to the adaptive model. Now the NextSentenceHead will be removed from the Adaptive model if next_sent_pred=True. This allows for turning off NSP by just setting the argument to False.