### PR TITLE
Fix sending prediction head to device after resizing

### DIFF
--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -31,12 +31,12 @@ def question_answering():
     ##########################
     set_all_seeds(seed=42)
     device, n_gpu = initialize_device_settings(use_cuda=True)
-    batch_size = 24
-    n_epochs = 2
-    evaluate_every = 500
+    batch_size = 32
+    n_epochs = 1
+    evaluate_every = 5000
     base_LM_model = "bert-base-cased"
-    train_filename="train-v2.0.json"
-    dev_filename="dev-v2.0.json"
+    train_filename="subsets/train_small-v2.0.json"
+    dev_filename="subsets/dev_small-v2.0.json"
 
     # 1.Create a tokenizer
     tokenizer = Tokenizer.load(
@@ -98,14 +98,14 @@ def question_answering():
 
     # 8. Hooray! You have a model. Store it:
     save_dir = Path("../saved_models/bert-english-qa-tutorial")
-    model.save(save_dir)
-    processor.save(save_dir)
-
+    # model.save(save_dir)
+    # processor.save(save_dir)
+    #
     # 9. Load it & harvest your fruits (Inference)
     QA_input = [
             {
-                "questions": ["Who counted the game among the best ever made?"],
-                "text":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
+                "qas": ["Who counted the game among the best ever made?"],
+                "context":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
             }]
 
     model = Inferencer.load(save_dir, batch_size=40, gpu=True)

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -31,12 +31,12 @@ def question_answering():
     ##########################
     set_all_seeds(seed=42)
     device, n_gpu = initialize_device_settings(use_cuda=True)
-    batch_size = 32
-    n_epochs = 1
-    evaluate_every = 5000
+    batch_size = 24
+    n_epochs = 2
+    evaluate_every = 500
     base_LM_model = "bert-base-cased"
-    train_filename="subsets/train_small-v2.0.json"
-    dev_filename="subsets/dev_small-v2.0.json"
+    train_filename="train-v2.0.json"
+    dev_filename="dev-v2.0.json"
 
     # 1.Create a tokenizer
     tokenizer = Tokenizer.load(
@@ -98,14 +98,14 @@ def question_answering():
 
     # 8. Hooray! You have a model. Store it:
     save_dir = Path("../saved_models/bert-english-qa-tutorial")
-    # model.save(save_dir)
-    # processor.save(save_dir)
-    #
+    model.save(save_dir)
+    processor.save(save_dir)
+
     # 9. Load it & harvest your fruits (Inference)
     QA_input = [
             {
-                "qas": ["Who counted the game among the best ever made?"],
-                "context":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
+                "questions": ["Who counted the game among the best ever made?"],
+                "text":  "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
             }]
 
     model = Inferencer.load(save_dir, batch_size=40, gpu=True)

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -39,6 +39,7 @@ class AdaptiveModel(nn.Module):
         :param device: The device on which this model will operate. Either "cpu" or "cuda".
         """
         super(AdaptiveModel, self).__init__()
+        self.device = device
         self.language_model = language_model.to(device)
         self.lm_output_dims = language_model.get_output_dims()
         self.prediction_heads = nn.ModuleList([ph.to(device) for ph in prediction_heads])
@@ -58,6 +59,7 @@ class AdaptiveModel(nn.Module):
         dimensionality of the language model. If it doesn't, it is resized so it does fit"""
         for ph in self.prediction_heads:
             ph.resize_input(self.lm_output_dims)
+            ph.to(self.device)
 
     def save(self, save_dir):
         """
@@ -271,6 +273,7 @@ class AdaptiveModel(nn.Module):
             else:
                 num_labels = len(label_list)
             head.resize_output(num_labels)
+            head.to(self.device)
             head.metric = tasks[head.task_name]["metric"]
 
     @classmethod


### PR DESCRIPTION
There was a bug that the prediction head would be moved to CPU when the feed forward component was resized. This ensures that it stays on the right device.