### PR TITLE
Undo Prediction Head Output Resizing 

### DIFF
--- a/examples/doc_classification.py
+++ b/examples/doc_classification.py
@@ -31,7 +31,7 @@ def doc_classifcation():
     evaluate_every = 100
     lang_model = "bert-base-german-cased"
     # or a local path:
-    lang_model = "../saved_models/farm-bert-base-cased-squad2"
+    # lang_model = Path("../saved_models/farm-bert-base-cased")
     use_amp = None
 
     device, n_gpu = initialize_device_settings(use_cuda=False, use_amp=use_amp)
@@ -66,7 +66,8 @@ def doc_classifcation():
     language_model = LanguageModel.load(lang_model)
     # b) and a prediction head on top that is suited for our task => Text classification
     prediction_head = TextClassificationHead(
-        class_weights=data_silo.calculate_class_weights(task_name="text_classification"))
+        class_weights=data_silo.calculate_class_weights(task_name="text_classification"),
+        num_labels=len(label_list))
 
     model = AdaptiveModel(
         language_model=language_model,
@@ -78,7 +79,7 @@ def doc_classifcation():
     # 5. Create an optimizer
     model, optimizer, lr_schedule = initialize_optimizer(
         model=model,
-        learning_rate=2e-5,
+        learning_rate=5e-3,
         device=device,
         n_batches=len(data_silo.loaders["train"]),
         n_epochs=n_epochs,

--- a/examples/doc_classification_cola.py
+++ b/examples/doc_classification_cola.py
@@ -65,7 +65,7 @@ def doc_classification_cola():
     # language_model = Roberta.load(lang_model)
     # b) and a prediction head on top that is suited for our task => Text classification
     prediction_head = TextClassificationHead(
-        layer_dims=[768, len(processor.tasks["text_classification"]["label_list"])],
+        num_labels=len(label_list),
         class_weights=data_silo.calculate_class_weights(task_name="text_classification"))
 
     model = AdaptiveModel(

--- a/examples/doc_classification_crossvalidation.py
+++ b/examples/doc_classification_crossvalidation.py
@@ -106,7 +106,8 @@ def doc_classification_crossvalidation():
         language_model = LanguageModel.load(lang_model)
         # b) and a prediction head on top that is suited for our task => Text classification
         prediction_head = TextClassificationHead(
-            class_weights=data_silo.calculate_class_weights(task_name="text_classification"))
+            class_weights=data_silo.calculate_class_weights(task_name="text_classification"),
+            num_labels=len(label_list))
 
         model = AdaptiveModel(
             language_model=language_model,

--- a/examples/doc_classification_multilabel.py
+++ b/examples/doc_classification_multilabel.py
@@ -56,7 +56,7 @@ def doc_classification_multilabel():
                                             train_filename="train.tsv",
                                             dev_filename="val.tsv",
                                             test_filename=None,
-                                            dev_split=0
+                                            dev_split=0,
                                             )
 
     # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
@@ -68,7 +68,7 @@ def doc_classification_multilabel():
     # a) which consists of a pretrained language model as a basis
     language_model = LanguageModel.load(lang_model)
     # b) and a prediction head on top that is suited for our task => Text classification
-    prediction_head = MultiLabelTextClassificationHead()
+    prediction_head = MultiLabelTextClassificationHead(num_labels=len(label_list))
 
     model = AdaptiveModel(
         language_model=language_model,

--- a/examples/doc_classification_multilabel_roberta.py
+++ b/examples/doc_classification_multilabel_roberta.py
@@ -55,7 +55,8 @@ def doc_classification_multilabel_roberta():
                                             train_filename=Path("train.tsv"),
                                             dev_filename=Path("val.tsv"),
                                             test_filename=None,
-                                            dev_split=0
+                                            dev_split=0,
+                                            max_samples=1000
                                             )
 
     # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
@@ -67,7 +68,7 @@ def doc_classification_multilabel_roberta():
     # a) which consists of a pretrained language model as a basis
     language_model = Roberta.load(lang_model)
     # b) and a prediction head on top that is suited for our task => Text classification
-    prediction_head = MultiLabelTextClassificationHead(layer_dims=[768, len(processor.tasks["text_classification"]["label_list"])])
+    prediction_head = MultiLabelTextClassificationHead(num_labels=len(label_list))
 
     model = AdaptiveModel(
         language_model=language_model,

--- a/examples/doc_classification_with_earlystopping.py
+++ b/examples/doc_classification_with_earlystopping.py
@@ -80,7 +80,7 @@ def doc_classification_with_earlystopping():
     # a) which consists of a pretrained language model as a basis
     language_model = LanguageModel.load(lang_model)
     # b) and a prediction head on top that is suited for our task => Text classification
-    prediction_head = TextClassificationHead(layer_dims=[768, len(processor.tasks["text_classification"]["label_list"])],
+    prediction_head = TextClassificationHead(num_labels=len(label_list),
                                              class_weights=data_silo.calculate_class_weights(task_name="text_classification"))
 
 

--- a/examples/lm_finetuning.py
+++ b/examples/lm_finetuning.py
@@ -55,7 +55,7 @@ def lm_finetuning():
 
     model = AdaptiveModel(
         language_model=language_model,
-        prediction_heads=[lm_prediction_head, next_sentence_head],
+        prediction_heads=[lm_prediction_head],
         embeds_dropout_prob=0.1,
         lm_output_types=["per_token", "per_sequence"],
         device=device,

--- a/examples/ner.py
+++ b/examples/ner.py
@@ -52,7 +52,7 @@ def ner():
     # a) which consists of a pretrained language model as a basis
     language_model = LanguageModel.load(lang_model)
     # b) and a prediction head on top that is suited for our task => NER
-    prediction_head = TokenClassificationHead()
+    prediction_head = TokenClassificationHead(num_labels=len(ner_labels))
 
     model = AdaptiveModel(
         language_model=language_model,

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -278,8 +278,6 @@ class AdaptiveModel(nn.Module):
                 num_labels = 1
             else:
                 num_labels = len(label_list)
-            head.resize_output(num_labels)
-            head.to(self.device)
             head.metric = tasks[head.task_name]["metric"]
 
     @classmethod

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -240,7 +240,7 @@ class RegressionHead(PredictionHead):
 class TextClassificationHead(PredictionHead):
     def __init__(
         self,
-        layer_dims=[768,1],
+        layer_dims=None,
         num_labels=None,
         class_weights=None,
         loss_ignore_index=-100,
@@ -261,10 +261,14 @@ class TextClassificationHead(PredictionHead):
         """
         super(TextClassificationHead, self).__init__()
         # num_labels could in most cases also be automatically retrieved from the data processor
-        self.layer_dims = layer_dims
-        self.num_labels = num_labels
-        if self.num_labels:
-            self.layer_dims = self.layer_dims[:-1] + [self.num_labels]
+        if num_labels:
+            self.layer_dims = [768, num_labels]
+        elif layer_dims:
+            self.layer_dims = layer_dims
+            logger.warning("`layer_dims` will be deprecated in future releases")
+        else:
+            raise ValueError("Please supply `num_labels` to define output dim of prediction head")
+        self.num_labels = self.layer_dims[-1]
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.num_labels = self.layer_dims[-1]
@@ -381,7 +385,7 @@ class TextClassificationHead(PredictionHead):
 class MultiLabelTextClassificationHead(PredictionHead):
     def __init__(
         self,
-        layer_dims=[768,1],
+        layer_dims=None,
         num_labels=None,
         class_weights=None,
         loss_reduction="none",
@@ -402,10 +406,14 @@ class MultiLabelTextClassificationHead(PredictionHead):
         """
         super(MultiLabelTextClassificationHead, self).__init__()
         # num_labels could in most cases also be automatically retrieved from the data processor
-        self.layer_dims = layer_dims
-        self.num_labels = num_labels
-        if self.num_labels:
-            self.layer_dims = self.layer_dims[:-1] + [self.num_labels]
+        if num_labels:
+            self.layer_dims = [768, num_labels]
+        elif layer_dims:
+            self.layer_dims = layer_dims
+            logger.warning("`layer_dims` will be deprecated in future releases")
+        else:
+            raise ValueError("Please supply `num_labels` to define output dim of prediction head")
+        self.num_labels = self.layer_dims[-1]
         logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         self.ph_output_type = "per_sequence"
@@ -485,7 +493,7 @@ class MultiLabelTextClassificationHead(PredictionHead):
 
 class TokenClassificationHead(PredictionHead):
     def __init__(self,
-                 layer_dims=[768,1],
+                 layer_dims=None,
                  num_labels=None,
                  task_name="ner",
                  **kwargs):
@@ -498,9 +506,14 @@ class TokenClassificationHead(PredictionHead):
         :param kwargs:
         """
         super(TokenClassificationHead, self).__init__()
-        self.layer_dims = layer_dims
         if num_labels:
-            self.layer_dims = self.layer_dims[:-1] + [num_labels]
+            self.layer_dims = [768, num_labels]
+        elif layer_dims:
+            self.layer_dims = layer_dims
+            logger.warning("`layer_dims` will be deprecated in future releases")
+        else:
+            raise ValueError("Please supply `num_labels` to define output dim of prediction head")
+        self.num_labels = self.layer_dims[-1]
         logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         self.num_labels = self.layer_dims[-1]

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -248,6 +248,17 @@ class TextClassificationHead(PredictionHead):
         task_name="text_classification",
         **kwargs,
     ):
+        """
+        :param layer_dims: The size of the layers in the feed forward component. The feed forward will have as many layers as there are ints in this list. This param will be deprecated in future
+        :type layer_dims: list
+        :param num_labels: The numbers of labels. Use to set the size of the final layer in the feed forward component. It is recommended to only set num_labels or layer_dims, not both.
+        :type num_labels: int
+        :param class_weights:
+        :param loss_ignore_index:
+        :param loss_reduction:
+        :param task_name:
+        :param kwargs:
+        """
         super(TextClassificationHead, self).__init__()
         # num_labels could in most cases also be automatically retrieved from the data processor
         self.layer_dims = layer_dims
@@ -255,6 +266,7 @@ class TextClassificationHead(PredictionHead):
         if self.num_labels:
             self.layer_dims = self.layer_dims[:-1] + [self.num_labels]
         self.feed_forward = FeedForwardBlock(self.layer_dims)
+        logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.num_labels = self.layer_dims[-1]
         self.ph_output_type = "per_sequence"
         self.model_type = "text_classification"
@@ -377,12 +389,24 @@ class MultiLabelTextClassificationHead(PredictionHead):
         pred_threshold=0.5,
         **kwargs,
     ):
+        """
+        :param layer_dims: The size of the layers in the feed forward component. The feed forward will have as many layers as there are ints in this list. This param will be deprecated in future
+        :type layer_dims: list
+        :param num_labels: The numbers of labels. Use to set the size of the final layer in the feed forward component. It is recommended to only set num_labels or layer_dims, not both.
+        :type num_labels: int
+        :param class_weights:
+        :param loss_reduction:
+        :param task_name:
+        :param pred_threshold:
+        :param kwargs:
+        """
         super(MultiLabelTextClassificationHead, self).__init__()
         # num_labels could in most cases also be automatically retrieved from the data processor
         self.layer_dims = layer_dims
         self.num_labels = num_labels
         if self.num_labels:
             self.layer_dims = self.layer_dims[:-1] + [self.num_labels]
+        logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         self.ph_output_type = "per_sequence"
         self.model_type = "multilabel_text_classification"
@@ -465,10 +489,19 @@ class TokenClassificationHead(PredictionHead):
                  num_labels=None,
                  task_name="ner",
                  **kwargs):
+        """
+        :param layer_dims: The size of the layers in the feed forward component. The feed forward will have as many layers as there are ints in this list. This param will be deprecated in future
+        :type layer_dims: list
+        :param num_labels: The numbers of labels. Use to set the size of the final layer in the feed forward component. It is recommended to only set num_labels or layer_dims, not both.
+        :type num_labels: int
+        :param task_name:
+        :param kwargs:
+        """
         super(TokenClassificationHead, self).__init__()
         self.layer_dims = layer_dims
         if num_labels:
             self.layer_dims = self.layer_dims[:-1] + [num_labels]
+        logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         self.num_labels = self.layer_dims[-1]
         self.loss_fct = CrossEntropyLoss(reduction="none")
@@ -829,7 +862,9 @@ class QuestionAnsweringHead(PredictionHead):
         """
         super(QuestionAnsweringHead, self).__init__()
         self.layer_dims = layer_dims
+        assert self.layer_dims[-1] == 2
         self.feed_forward = FeedForwardBlock(self.layer_dims)
+        logger.info(f"Prediction head initialized with size {self.layer_dims}")
         self.num_labels = self.layer_dims[-1]
         self.ph_output_type = "per_token_squad"
         self.model_type = (

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -167,23 +167,6 @@ class PredictionHead(nn.Module):
             self.layer_dims[0] = input_dim
             self.feed_forward.layer_dims[0] = input_dim
 
-    def resize_output(self, output_dim):
-        """ This function compares the number of labels against the output dimensionality
-        of the prediction head. If there is a mismatch, the prediction head will be resized to fit."""
-        if "feed_forward" not in dir(self):
-            return
-        else:
-            old_dims = self.feed_forward.layer_dims
-            if output_dim == old_dims[-1]:
-                return
-            new_dims = old_dims[:-1] + [output_dim]
-            logger.info(f"Resizing output dimensions of {type(self).__name__} ({self.task_name}) "
-                  f"from {old_dims} to {new_dims} to match number of labels")
-            self.feed_forward = FeedForwardBlock(new_dims)
-            self.layer_dims[-1] = output_dim
-            self.feed_forward.layer_dims[-1] = output_dim
-            self.num_labels = output_dim
-
     @classmethod
     def _get_model_file(cls, config_file):
         if "config.json" in str(config_file) and "prediction_head" in str(config_file):
@@ -258,6 +241,7 @@ class TextClassificationHead(PredictionHead):
     def __init__(
         self,
         layer_dims=[768,1],
+        num_labels=None,
         class_weights=None,
         loss_ignore_index=-100,
         loss_reduction="none",
@@ -267,6 +251,9 @@ class TextClassificationHead(PredictionHead):
         super(TextClassificationHead, self).__init__()
         # num_labels could in most cases also be automatically retrieved from the data processor
         self.layer_dims = layer_dims
+        self.num_labels = num_labels
+        if self.num_labels:
+            self.layer_dims = self.layer_dims[:-1] + [self.num_labels]
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         self.num_labels = self.layer_dims[-1]
         self.ph_output_type = "per_sequence"
@@ -383,6 +370,7 @@ class MultiLabelTextClassificationHead(PredictionHead):
     def __init__(
         self,
         layer_dims=[768,1],
+        num_labels=None,
         class_weights=None,
         loss_reduction="none",
         task_name="text_classification",
@@ -392,8 +380,10 @@ class MultiLabelTextClassificationHead(PredictionHead):
         super(MultiLabelTextClassificationHead, self).__init__()
         # num_labels could in most cases also be automatically retrieved from the data processor
         self.layer_dims = layer_dims
+        self.num_labels = num_labels
+        if self.num_labels:
+            self.layer_dims = self.layer_dims[:-1] + [self.num_labels]
         self.feed_forward = FeedForwardBlock(self.layer_dims)
-        self.num_labels = self.layer_dims[-1]
         self.ph_output_type = "per_sequence"
         self.model_type = "multilabel_text_classification"
         self.task_name = task_name #used for connecting with the right output of the processor
@@ -470,9 +460,15 @@ class MultiLabelTextClassificationHead(PredictionHead):
 
 
 class TokenClassificationHead(PredictionHead):
-    def __init__(self, layer_dims=[768,1], task_name="ner", **kwargs):
+    def __init__(self,
+                 layer_dims=[768,1],
+                 num_labels=None,
+                 task_name="ner",
+                 **kwargs):
         super(TokenClassificationHead, self).__init__()
         self.layer_dims = layer_dims
+        if num_labels:
+            self.layer_dims = self.layer_dims[:-1] + [num_labels]
         self.feed_forward = FeedForwardBlock(self.layer_dims)
         self.num_labels = self.layer_dims[-1]
         self.loss_fct = CrossEntropyLoss(reduction="none")
@@ -818,7 +814,7 @@ class QuestionAnsweringHead(PredictionHead):
     A question answering head predicts the start and end of the answer on token level.
     """
 
-    def __init__(self, layer_dims=[768,1], task_name="question_answering", no_ans_threshold=0.0, context_window_size=100, n_best=5, **kwargs):
+    def __init__(self, layer_dims=[768,2], task_name="question_answering", no_ans_threshold=0.0, context_window_size=100, n_best=5, **kwargs):
         """
         :param layer_dims: dimensions of Feed Forward block, e.g. [768,2], for adjusting to BERT embedding. Output should be always 2
         :type layer_dims: List[Int]

--- a/test/test_doc_classification.py
+++ b/test/test_doc_classification.py
@@ -46,7 +46,7 @@ def test_doc_classification(caplog=None):
         batch_size=batch_size)
 
     language_model = LanguageModel.load(lang_model)
-    prediction_head = TextClassificationHead()
+    prediction_head = TextClassificationHead(num_labels=2)
     model = AdaptiveModel(
         language_model=language_model,
         prediction_heads=[prediction_head],

--- a/test/test_doc_classification_distilbert.py
+++ b/test/test_doc_classification_distilbert.py
@@ -45,7 +45,7 @@ def test_doc_classification(caplog=None):
         batch_size=batch_size)
 
     language_model = DistilBert.load(lang_model)
-    prediction_head = TextClassificationHead()
+    prediction_head = TextClassificationHead(num_labels=2)
     model = AdaptiveModel(
         language_model=language_model,
         prediction_heads=[prediction_head],

--- a/test/test_doc_classification_roberta.py
+++ b/test/test_doc_classification_roberta.py
@@ -43,7 +43,7 @@ def test_doc_classification():
         batch_size=batch_size)
 
     language_model = Roberta.load(lang_model)
-    prediction_head = TextClassificationHead()
+    prediction_head = TextClassificationHead(num_labels=2)
     model = AdaptiveModel(
         language_model=language_model,
         prediction_heads=[prediction_head],

--- a/test/test_ner.py
+++ b/test/test_ner.py
@@ -48,7 +48,7 @@ def test_ner(caplog=None):
 
     data_silo = DataSilo(processor=processor, batch_size=batch_size, max_processes=1)
     language_model = LanguageModel.load(lang_model)
-    prediction_head = TokenClassificationHead()
+    prediction_head = TokenClassificationHead(num_labels=13)
 
     model = AdaptiveModel(
         language_model=language_model,

--- a/test/test_ner_amp.py
+++ b/test/test_ner_amp.py
@@ -50,7 +50,7 @@ def test_ner():
 
     data_silo = DataSilo(processor=processor, batch_size=batch_size, max_processes=1)
     language_model = LanguageModel.load(lang_model)
-    prediction_head = TokenClassificationHead()
+    prediction_head = TokenClassificationHead(num_labels=13)
 
     model = AdaptiveModel(
         language_model=language_model,


### PR DESCRIPTION
The way that prediction head output resizing was happening meant that the prediction head's weight matrix was at risk of not receiving gradient updates. This PR undoes those changes. Now users need to specify the number of labels when using the TextClassificationHeads or TokenClassificationHeads 