### PR TITLE
Improve traceback for errors happening during multiprocessing in datasilo

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -268,14 +268,22 @@ class Processor(ABC):
     def _init_samples_in_baskets(self):
         for basket in self.baskets:
             all_dicts = [b.raw for b in self.baskets]
-            basket.samples = self._dict_to_samples(dictionary=basket.raw, all_dicts=all_dicts)
-            for num, sample in enumerate(basket.samples):
-                 sample.id = f"{basket.id}-{num}"
+            try:
+                basket.samples = self._dict_to_samples(dictionary=basket.raw, all_dicts=all_dicts)
+                for num, sample in enumerate(basket.samples):
+                     sample.id = f"{basket.id}-{num}"
+            except:
+                logger.error(f"Could not create sample(s) from this dict: \n {basket.raw}")
+                raise
 
     def _featurize_samples(self):
         for basket in self.baskets:
             for sample in basket.samples:
-                sample.features = self._sample_to_features(sample=sample)
+                try:
+                    sample.features = self._sample_to_features(sample=sample)
+                except:
+                    logger.error(f"Could not convert this sample to features: \n {sample}")
+                    raise
 
     def _create_dataset(self, keep_baskets=False):
         features_flat = []


### PR DESCRIPTION
Making sure exceptions are raised from the child process with a better traceback. 
Also adding logging of the dictionary/sample that caused the issue during conversion.
This might help in situations where the preprocessing fails for certain examples.

Example for artificial error in dict_to_samples():

``` 
01/28/2020 11:15:27 - ERROR - farm.data_handler.processor -   Could not create sample(s) from this dict: 
 {'text': '@MiriamOzen Wie klar und deutlich sollen wir es ihr noch zeigen... |LBR| Wir wollen und brauchen ihre Dienste nicht mehr...!!!!', 'text_classification_label': 'OTHER'}
Preprocessing Dataset:   9%|▊         | 432/5009 [00:01<00:15, 289.63 Dicts/s]
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/mp/miniconda3/envs/py37/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/home/mp/deepset/dev/FARM/farm/data_handler/data_silo.py", line 101, in _dataset_from_chunk
    dataset = processor.dataset_from_dicts(dicts=dicts, indices=indices)
  File "/home/mp/deepset/dev/FARM/farm/data_handler/processor.py", line 323, in dataset_from_dicts
    self._init_samples_in_baskets()
  File "/home/mp/deepset/dev/FARM/farm/data_handler/processor.py", line 272, in _init_samples_in_baskets
    basket.samples = self._dict_to_samples(dictionary=basket.raw, all_dicts=all_dicts)
  File "/home/mp/deepset/dev/FARM/farm/data_handler/processor.py", line 478, in _dict_to_samples
    dictionary["test"]
KeyError: 'test'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/mp/deepset/dev/FARM/examples/doc_classification.py", line 119, in <module>
    doc_classifcation()
  File "/home/mp/deepset/dev/FARM/examples/doc_classification.py", line 63, in doc_classifcation
    caching=False)
  File "/home/mp/deepset/dev/FARM/farm/data_handler/data_silo.py", line 82, in __init__
    self._load_data()
  File "/home/mp/deepset/dev/FARM/farm/data_handler/data_silo.py", line 179, in _load_data
    self.data["train"], self.tensor_names = self._get_dataset(train_file)
  File "/home/mp/deepset/dev/FARM/farm/data_handler/data_silo.py", line 150, in _get_dataset
    for dataset, tensor_names in results:
  File "/home/mp/miniconda3/envs/py37/lib/python3.7/multiprocessing/pool.py", line 748, in next
    raise value
KeyError: 'test'

Process finished with exit code 1
``` 