### PR TITLE
Add option for custom loss aggregation of heads

### DIFF
--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -44,7 +44,7 @@ class AdaptiveModel(nn.Module):
                                     Note: The loss at this stage is per sample,
                                     i.e one tensor of shape (batchsize) per prediction head.
                                     Default is sum(), but you can configure any fn that takes
-                                    [Tensor, Tensor ...] and returns [Tensor].
+                                    [Tensor, Tensor ...] and returns a single Tensor.
         :type loss_aggregation_fn: function
         """
 

--- a/farm/train.py
+++ b/farm/train.py
@@ -436,7 +436,7 @@ class Trainer:
 
                 # Forward pass through model
                 logits = self.model.forward(**batch)
-                per_sample_loss = self.model.logits_to_loss(logits=logits, **batch)
+                per_sample_loss = self.model.logits_to_loss(logits=logits, global_step=self.global_step, **batch)
 
                 loss = self.backward_propagate(per_sample_loss, step)
 


### PR DESCRIPTION
**Context:** 
Each prediction head produces a loss that gets then aggregated to a full model loss. So far we used `sum()` as the aggregation function. 

**Problem:**
This is not optimal in the case of multiple PHs as it impacts the scale of the loss and therefore might require adjustments of the learning rate. 
It also doesn't allow weighting of different prediction heads, where one task might be more important or just on a different loss scale.

**Solution:**
I would suggest to make this more flexible and let the user define a custom strategy via 
`loss_aggregation_fn`, which can be passed when initializing the AdaptiveModel. 

Default of `loss_aggregation_fn` will be sum(), but you can configure any fn that [Tensor, Tensor ...] and returns a single Tensor.

**Example:**
``` 
    import torch
    loss_fn = lambda x: torch.mean(torch.stack(x), dim=0)

    model = AdaptiveModel(
        language_model=language_model,
        prediction_heads=[lm_prediction_head, next_sentence_head],
        embeds_dropout_prob=0.1,
        lm_output_types=["per_token", "per_sequence"],
        device=device,
        loss_aggregation_fn=loss_fn
    )
```
Related to discussion in #182 

What do you think @johann-petrak ? 
Would that also cover your use cases? 
 