### PR TITLE
Add Support for NER models to be converted to and from HF Transformers

### DIFF
--- a/farm/infer.py
+++ b/farm/infer.py
@@ -184,15 +184,13 @@ class Inferencer:
             #                                             quote_char='"',
             #                                             multilabel=True,
             #                                             )
-            # TODO NER style in FARM differs because we have the "X" label for subword tokens
-            # elif task_type == "ner":
-            #     label_list = list(config.label2id.keys())
-            #     # label_list = ["[PAD]", "X", "O", "B-MISC", "I-MISC", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC",
-            #     #               "I-LOC", "B-OTH", "I-OTH"]
-            #     processor = NERProcessor(
-            #         tokenizer=tokenizer, max_seq_len=256, data_dir=None, metric="seq_f1",
-            #         label_list=label_list
-            #     )
+
+            elif task_type == "ner":
+                label_list = list(config.label2id.keys())
+                processor = NERProcessor(
+                    tokenizer=tokenizer, max_seq_len=max_seq_len, data_dir=None, metric="seq_f1",
+                    label_list=label_list
+                )
             else:
                 raise ValueError(f"`task_type` {task_type} is not supported yet. "
                                  f"Valid options for arg `task_type`: 'question_answering', 'embeddings', 'text_classification'")

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from farm.modeling.language_model import LanguageModel
 from farm.modeling.prediction_head import PredictionHead, BertLMHead, QuestionAnsweringHead, TokenClassificationHead, TextClassificationHead
-from transformers.modeling_auto import AutoModelForQuestionAnswering, AutoModelForSequenceClassification
+from transformers.modeling_auto import AutoModelForQuestionAnswering, AutoModelForSequenceClassification, AutoModelForTokenClassification
 from farm.utils import MLFlowLogger as MlLogger
 
 logger = logging.getLogger(__name__)
@@ -362,6 +362,8 @@ class AdaptiveModel(nn.Module):
             self.language_model.model.config.label2id = {label: id for id, label in enumerate(self.prediction_heads[0].label_list)}
             self.language_model.model.config.finetuning_task = "text_classification"
             self.language_model.model.config.language = self.language_model.language
+            # TODO This line might be needed for cases where we are doing text classification with more than 2 classes
+            # self.language_model.model.config.num_labels = self.prediction_heads[0].num_labels
 
             # init model
             transformers_model = AutoModelForSequenceClassification.from_config(self.language_model.model.config)
@@ -369,7 +371,20 @@ class AdaptiveModel(nn.Module):
             setattr(transformers_model, transformers_model.base_model_prefix, self.language_model.model)
             transformers_model.classifier.load_state_dict(
                 self.prediction_heads[0].feed_forward.feed_forward[0].state_dict())
+        elif self.prediction_heads[0].model_type == "token_classification":
+            # add more info to config
+            self.language_model.model.config.id2label = {id: label for id, label in enumerate(self.prediction_heads[0].label_list)}
+            self.language_model.model.config.label2id = {label: id for id, label in enumerate(self.prediction_heads[0].label_list)}
+            self.language_model.model.config.finetuning_task = "token_classification"
+            self.language_model.model.config.language = self.language_model.language
+            self.language_model.model.config.num_labels = self.prediction_heads[0].num_labels
 
+            # init model
+            transformers_model = AutoModelForTokenClassification.from_config(self.language_model.model.config)
+            # transfer weights for language model + prediction head
+            setattr(transformers_model, transformers_model.base_model_prefix, self.language_model.model)
+            transformers_model.classifier.load_state_dict(
+                self.prediction_heads[0].feed_forward.feed_forward[0].state_dict())
         else:
             raise NotImplementedError(f"FARM -> Transformers conversion is not supported yet for"
                                       f" prediction heads of type {self.prediction_heads[0].model_type}")
@@ -407,15 +422,14 @@ class AdaptiveModel(nn.Module):
             ph = QuestionAnsweringHead.load(model_name_or_path)
             adaptive_model = cls(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
                                lm_output_types="per_token", device=device)
-
         elif task_type == "text_classification":
             ph = TextClassificationHead.load(model_name_or_path)
             adaptive_model = cls(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
                                  lm_output_types="per_sequence", device=device)
-        # elif task_type == "ner":
-        #     ph = TokenClassificationHead.load(model_name_or_path)
-        #     adaptive_model = cls(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
-        #                        lm_output_types="per_token", device=device)
+        elif task_type == "ner":
+            ph = TokenClassificationHead.load(model_name_or_path)
+            adaptive_model = cls(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
+                               lm_output_types="per_token", device=device)
         elif task_type == "embeddings":
             adaptive_model = cls(language_model=lm, prediction_heads=[], embeds_dropout_prob=0.1,
                                  lm_output_types=["per_token", "per_sequence"], device=device)

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -362,8 +362,7 @@ class AdaptiveModel(nn.Module):
             self.language_model.model.config.label2id = {label: id for id, label in enumerate(self.prediction_heads[0].label_list)}
             self.language_model.model.config.finetuning_task = "text_classification"
             self.language_model.model.config.language = self.language_model.language
-            # TODO This line might be needed for cases where we are doing text classification with more than 2 classes
-            # self.language_model.model.config.num_labels = self.prediction_heads[0].num_labels
+            self.language_model.model.config.num_labels = self.prediction_heads[0].num_labels
 
             # init model
             transformers_model = AutoModelForSequenceClassification.from_config(self.language_model.model.config)

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -542,15 +542,15 @@ class TokenClassificationHead(PredictionHead):
             # a) FARM style
             return super(TokenClassificationHead, cls).load(pretrained_model_name_or_path)
         else:
-            raise NotImplementedError("Loading prediction head from transformers format is not supported yet.")
-            # # b) transformers style
-            # # load all weights from model
-            # full_model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name_or_path)
-            # # init empty head
-            # head = cls(layer_dims=[full_model.config.hidden_size, len(full_model.config.label2id)])
-            # # transfer weights for head from full model
-            # head.feed_forward.feed_forward[0].load_state_dict(full_model.classifier.state_dict())
-            # del full_model
+            # b) transformers style
+            # load all weights from model
+            full_model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name_or_path)
+            # init empty head
+            head = cls(layer_dims=[full_model.config.hidden_size, len(full_model.config.label2id)])
+            # transfer weights for head from full model
+            head.feed_forward.feed_forward[0].load_state_dict(full_model.classifier.state_dict())
+            del full_model
+            return head
 
 
     def forward(self, X):


### PR DESCRIPTION
These changes allow for NER models to be converted to and from HF Transformers. Tests have been done to make sure models give the  same predictions in either framework.