### PR TITLE
Allow for multiple queries in QA inference when using rest_api format

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -960,23 +960,16 @@ class SquadProcessor(Processor):
         return raw_baskets
 
     def _convert_rest_api_dict(self, infer_dict):
-        # convert input coming from inferencer to SQuAD format
-        if len(infer_dict.get("questions")) > 1:
-            raise ValueError("Inferencer currently does not support answering multiple questions on a text."
-                                "As a workaround, multiple input dicts with text and question pairs can be "
-                                "supplied in a single API request.")
-        converted = {
-            "qas": [
-                {
-                    "question": infer_dict.get("questions", ["Missing?"])[0],
-                    "id": None,
-                    "answers": [],
-                    "is_impossible": False
-                }
-            ],
-            "context": infer_dict.get("text", "Missing!"),
-            "document_id": infer_dict.get("document_id", None),
-        }
+        questions = infer_dict.get("questions", ["[Missing]"])
+        text = infer_dict.get("text", "Missing!")
+        doc_id = infer_dict.get("document_id", None)
+        qas = [{"question": q,
+                "id": i,
+                "answers": [],
+                "is_impossible": False} for i, q in enumerate(questions)]
+        converted = {"qas": qas,
+                     "context": text,
+                     "document_id": doc_id}
         return converted
 
     def file_to_dicts(self, file: str) -> [dict]:

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -924,7 +924,6 @@ class SquadProcessor(Processor):
             raise Exception("It seems that your input is in rest API format. Try setting rest_api_schema=True "
                             "when calling inference from dicts")
         document_text = dictionary["context"]
-        document_id = dictionary.get("document_id", None)
 
         document_tokenized = tokenize_with_metadata(document_text, self.tokenizer)
         document_start_of_word = [int(x) for x in document_tokenized["start_of_word"]]
@@ -954,7 +953,6 @@ class SquadProcessor(Processor):
                    "document_tokens": document_tokenized["tokens"],
                    "document_offsets": document_tokenized["offsets"],
                    "document_start_of_word": document_start_of_word,
-                   "document_id": document_id,
                    "question_text": question_text,
                    "question_tokens": question_tokenized["tokens"],
                    "question_offsets": question_tokenized["offsets"],
@@ -968,14 +966,12 @@ class SquadProcessor(Processor):
     def _convert_rest_api_dict(self, infer_dict):
         questions = infer_dict.get("questions", ["[Missing]"])
         text = infer_dict.get("text", "Missing!")
-        doc_id = infer_dict.get("document_id", None)
         qas = [{"question": q,
                 "id": i,
                 "answers": [],
                 "is_impossible": False} for i, q in enumerate(questions)]
         converted = {"qas": qas,
-                     "context": text,
-                     "document_id": doc_id}
+                     "context": text}
         return converted
 
     def file_to_dicts(self, file: str) -> [dict]:

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -920,7 +920,12 @@ class SquadProcessor(Processor):
         where each entry is a dictionary for one document-question pair (potentially mutliple answers). """
 
         raw_baskets = []
+        if "text" in dictionary and "context" not in dictionary:
+            raise Exception("It seems that your input is in rest API format. Try setting rest_api_schema=True "
+                            "when calling inference from dicts")
         document_text = dictionary["context"]
+        document_id = dictionary.get("document_id", None)
+
         document_tokenized = tokenize_with_metadata(document_text, self.tokenizer)
         document_start_of_word = [int(x) for x in document_tokenized["start_of_word"]]
         questions = dictionary["qas"]
@@ -949,6 +954,7 @@ class SquadProcessor(Processor):
                    "document_tokens": document_tokenized["tokens"],
                    "document_offsets": document_tokenized["offsets"],
                    "document_start_of_word": document_start_of_word,
+                   "document_id": document_id,
                    "question_text": question_text,
                    "question_tokens": question_tokenized["tokens"],
                    "question_offsets": question_tokenized["offsets"],
@@ -1075,7 +1081,7 @@ class RegressionProcessor(Processor):
         )
 
         # Note that label_list is being hijacked to store the scaling mean and scale
-        self.add_task(name="regression", metric="mse", label_list= [scaler_mean, scaler_scale], label_column_name=label_column_name, task_type="regression", label_name=label_name)
+        self.add_task(name="regression", metric="mse", label_list=[scaler_mean, scaler_scale], label_column_name=label_column_name, task_type="regression", label_name=label_name)
 
     def file_to_dicts(self, file: str) -> [dict]:
         column_mapping = {task["label_column_name"]: task["label_name"] for task in self.tasks.values()}

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -252,11 +252,9 @@ class Inferencer:
             )
 
         # Assign a sequential doc_id to each dictionary
-        old_dicts = dicts
-        dicts = []
-        for i, d in enumerate(old_dicts):
-            d["document_id"] = i
-            dicts.append(d)
+        if rest_api_schema:
+            for i, d in enumerate(dicts):
+                d["document_id"] = i
 
         # Using multiprocessing
         if max_processes > 1:  # use multiprocessing if max_processes > 1

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -251,11 +251,6 @@ class Inferencer:
                 f"b) ... run inference on a downstream task: make sure your model path {self.name} contains a saved prediction head"
             )
 
-        # Assign a sequential doc_id to each dictionary
-        if rest_api_schema:
-            for i, d in enumerate(dicts):
-                d["document_id"] = i
-
         # Using multiprocessing
         if max_processes > 1:  # use multiprocessing if max_processes > 1
             multiprocessing_chunk_size, num_cpus_used = calc_chunksize(len(dicts), max_processes)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -251,6 +251,13 @@ class Inferencer:
                 f"b) ... run inference on a downstream task: make sure your model path {self.name} contains a saved prediction head"
             )
 
+        # Assign a sequential doc_id to each dictionary
+        old_dicts = dicts
+        dicts = []
+        for i, d in enumerate(old_dicts):
+            d["document_id"] = i
+            dicts.append(d)
+
         # Using multiprocessing
         if max_processes > 1:  # use multiprocessing if max_processes > 1
             multiprocessing_chunk_size, num_cpus_used = calc_chunksize(len(dicts), max_processes)

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1164,7 +1164,7 @@ class QuestionAnsweringHead(PredictionHead):
         ret = []
         token_offsets = basket.raw["document_offsets"]
         clear_text = basket.raw["document_text"]
-        document_id = basket.raw["document_id"]
+        document_id = basket.id.split("-")[0]
 
         # iterate over the top_n predictions of the one document
         for string, start_t, end_t, score in top_preds:

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1164,6 +1164,7 @@ class QuestionAnsweringHead(PredictionHead):
         ret = []
         token_offsets = basket.raw["document_offsets"]
         clear_text = basket.raw["document_text"]
+        document_id = basket.raw["document_id"]
 
         # iterate over the top_n predictions of the one document
         for string, start_t, end_t, score in top_preds:
@@ -1178,7 +1179,7 @@ class QuestionAnsweringHead(PredictionHead):
                     "context": context_string,
                     "offset_context_start": context_start_ch,
                     "offset_context_end": context_end_ch,
-                    "document_id": None}
+                    "document_id": document_id}
             ret.append(curr)
         return ret
 


### PR DESCRIPTION
This PR allows for QA inference to handle multiple queries for a single doc when using rest api mode. This addresses #242 