### PR TITLE
Pin Werkzeug version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ transformers==2.4.0
 # accessing dictionary elements with dot notation
 dotmap==1.3.0
 # for inference-rest-apis
+Werkzeug==0.16.1
 flask
 flask-restplus
 flask-cors


### PR DESCRIPTION
`flask-restplus` library is broken by a recent update of `Werkzeug`(https://github.com/noirbizarre/flask-restplus/issues/777).  As a quick-fix, we pin the version for Werkzeug in FARM requirements.