### PR TITLE
Refactor no answer handling in Question Answering

### DIFF
--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -36,8 +36,8 @@ def question_answering():
     evaluate_every = 2000
     lang_model = "roberta-base"
     do_lower_case = False # roberta is a cased model
-    train_filename = "train-sample2.json"#"train-v2.0.json"
-    dev_filename = "train-sample2.json" #"dev-v2.0.json"
+    train_filename = "train-v2.0.json"
+    dev_filename = "dev-v2.0.json"
 
     # 1.Create a tokenizer
     tokenizer = Tokenizer.load(

--- a/examples/question_answering.py
+++ b/examples/question_answering.py
@@ -36,8 +36,8 @@ def question_answering():
     evaluate_every = 2000
     lang_model = "roberta-base"
     do_lower_case = False # roberta is a cased model
-    train_filename = "train-v2.0.json"
-    dev_filename = "dev-v2.0.json"
+    train_filename = "train-sample2.json"#"train-v2.0.json"
+    dev_filename = "train-sample2.json" #"dev-v2.0.json"
 
     # 1.Create a tokenizer
     tokenizer = Tokenizer.load(

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -141,7 +141,10 @@ def read_squad_file(filename, proxies=None):
 def write_squad_predictions(predictions, out_filename, predictions_filename=None):
     predictions_json = {}
     for p in predictions:
-        predictions_json[p["id"]] = p["preds"][0][0]
+        if p["preds"][0][0] is not None:
+            predictions_json[p["id"]] = p["preds"][0][0]
+        else:
+            predictions_json[p["id"]] = "" #convert No answer = None to format understood by the SQuAD eval script
 
     if predictions_filename:
         dev_labels = {}

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -217,6 +217,7 @@ class Inferencer:
         :param file: path of the input file for Inference
         :type file: str
         :param max_processes: the maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
+                              If you want to debug, you need to disable multiprocessing!
         :type max_processes: int
         """
         dicts = self.processor.file_to_dicts(file)
@@ -239,9 +240,11 @@ class Inferencer:
                                 While input is almost the same, output contains additional meta data(offset, context..)
         :type rest_api_schema: bool
         :return: dict of predictions
-        :param max_processes: the maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
-            For very small number of dicts, time incurred in spawning processes could outweigh performance boost, eg,
-            in the case of HTTP APIs for Inference. For such cases, multiprocessing can be disabled using this param.
+        :param max_processes: The maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
+                              If you want to debug, you need to disable multiprocessing!
+                              For very small number of dicts, time incurred in spawning processes could outweigh
+                              performance boost, eg, in the case of HTTP APIs for Inference. For such cases
+                              multiprocessing should be disabled.
         """
         if self.prediction_type == "embedder":
             raise TypeError(
@@ -276,7 +279,7 @@ class Inferencer:
                 preds_all = []
                 with tqdm(total=len(dicts), unit=" Dicts") as pbar:
                     for dataset, tensor_names, baskets in results:
-                        # TODO change formot of formatted_preds in QA (list of dicts)
+                        # TODO change format of formatted_preds in QA (list of dicts)
                         preds_all.extend(self._get_predictions(dataset, tensor_names, baskets, rest_api_schema))
                         pbar.update(multiprocessing_chunk_size)
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -217,7 +217,7 @@ class Inferencer:
         :param file: path of the input file for Inference
         :type file: str
         :param max_processes: the maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
-                              If you want to debug, you need to disable multiprocessing!
+                              If you want to debug the Language Model, you might need to disable multiprocessing!
         :type max_processes: int
         """
         dicts = self.processor.file_to_dicts(file)
@@ -241,7 +241,7 @@ class Inferencer:
         :type rest_api_schema: bool
         :return: dict of predictions
         :param max_processes: The maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
-                              If you want to debug, you need to disable multiprocessing!
+                              If you want to debug the Language Model, you might need to disable multiprocessing!
                               For very small number of dicts, time incurred in spawning processes could outweigh
                               performance boost, eg, in the case of HTTP APIs for Inference. For such cases
                               multiprocessing should be disabled.

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1104,7 +1104,7 @@ class QuestionAnsweringHead(PredictionHead):
         preds_d = self.aggregate_preds(preds_p, passage_start_t, ids, seq_2_start_t)
         assert len(preds_d) == len(baskets)
 
-        # Separate top_preds list from the no_ans_gap float. Add no_ans_gap to current boost for switching
+        # Separate top_preds list from the no_ans_gap float.
         top_preds, no_ans_gaps = zip(*preds_d)
 
         # Takes document level prediction spans and returns string predictions
@@ -1154,7 +1154,7 @@ class QuestionAnsweringHead(PredictionHead):
                         "question_id": id,
                         "ground_truth": None,
                         "answers": answers,
-                        "no_ans_gap": no_ans_gap
+                        "no_ans_gap": no_ans_gap # Add no_ans_gap to current no_ans_boost for switching top prediction
                     }
                 ],
             }

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1332,16 +1332,16 @@ class QuestionAnsweringHead(PredictionHead):
         pos_answer_dedup = self.deduplicate(pos_answers_flat)
 
         # This is how much no_answer_boost needs to change to turn a no_answer to a positive answer (or vice versa)
-        change_boost = min([nas - pbs for nas, pbs in zip(no_answer_scores, passage_best_score)])
+        change_boost = -min([nas - pbs for nas, pbs in zip(no_answer_scores, passage_best_score)])
 
         # "no answer" scores and positive answers scores are difficult to compare, because
         # + a positive answer score is related to a specific text span
         # - a "no answer" score is related to all input texts
         # Thus we compute the "no answer" score relative to the best possible answer and adjust it by
         # the most significant difference between scores.
-        # Most significant difference: a model switching from predicting an answer to "no answer" (or vice versa).
+        # Most significant difference: change top prediction from "no answer" to answer (or vice versa)
         best_overall_positive_score = max(x[2] for x in pos_answer_dedup)
-        no_answer_pred = [-1, -1, best_overall_positive_score + change_boost]
+        no_answer_pred = [-1, -1, best_overall_positive_score - change_boost]
 
 
         # Add no answer to positive answers, sort the order and return the n_best

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1330,7 +1330,7 @@ class QuestionAnsweringHead(PredictionHead):
         # TODO add switch for more variation in answers, e.g. if varied_ans then never return overlapping answers
         pos_answer_dedup = self.deduplicate(pos_answers_flat)
 
-        # This is how much no_answer_boost needs to change to turn a no_answer to a positive answer (or vice versa)
+        # This is how much no_ans_boost needs to change to turn a no_answer to a positive answer (or vice versa)
         no_ans_gap = -min([nas - pbs for nas, pbs in zip(no_answer_scores, passage_best_score)])
 
         # "no answer" scores and positive answers scores are difficult to compare, because


### PR DESCRIPTION
This PR will need adjustments from downstream applications consuming QA inference, since we now return None for no answer (instead of empty string)

1. Change naming to no answer boost.
2. Change how no answer score is computed. 
3. Predictions contain a no answer along positive answers, the no answer score is relative to positive answers. 