### PR TITLE
Add document id to QA inference

### DIFF
--- a/farm/data_handler/samples.py
+++ b/farm/data_handler/samples.py
@@ -13,13 +13,17 @@ class SampleBasket:
 
     def __init__(self, id: str, raw: dict, external_id=None, samples=None):
         """
-        :param id: A unique identifying id.
+        :param id: A unique identifying id. Used for identification within FARM.
         :type id: str
+        :param external_id: Used for identification outside of FARM. E.g. if another framework wants to pass along its own id with the results.
+        :type external_id: str
         :param raw: Contains the various data needed to form a sample. It is ideally in human readable form.
         :type raw: dict
         :param samples: An optional list of Samples used to populate the basket at initialization.
+        :type samples: Sample
         """
         self.id = id
+        self.external_id = external_id
         self.raw = raw
         self.samples = samples
 

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1165,7 +1165,8 @@ class QuestionAnsweringHead(PredictionHead):
         ret = []
         token_offsets = basket.raw["document_offsets"]
         clear_text = basket.raw["document_text"]
-        document_id = basket.id.split("-")[0]
+        # In the context of QA, the external ID of our general Basket becomes a document ID again
+        document_id = basket.external_id
 
         # iterate over the top_n predictions of the one document
         for string, start_t, end_t, score in top_preds:


### PR DESCRIPTION
Adds a document id to pass along the data going through the Inferencer.

Makes use of the already existing (but ignored) external ID field in our basket.