### PR TITLE
Fix progress bar in datasilo

### DIFF
--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -157,11 +157,14 @@ class DataSilo:
 
             datasets = []
 
-            with tqdm(total=len(dicts), unit=' Dicts', desc="Preprocessing Dataset") as pbar:
+            desc = f"Preprocessing Dataset"
+            if filename:
+                desc += f" {filename}"
+            with tqdm(total=len(dicts), unit=' Dicts', desc=desc) as pbar:
                 for dataset, tensor_names in results:
                     datasets.append(dataset)
-                    pbar.update(multiprocessing_chunk_size)
-
+                    # update progress bar (last step can have less dicts than actual chunk_size)
+                    pbar.update(min(multiprocessing_chunk_size, pbar.total-pbar.n))
             concat_datasets = ConcatDataset(datasets)
             return concat_datasets, tensor_names
 


### PR DESCRIPTION
We were updating our progress bar with a fixed chunk_size (e.g. 10). 
If the last chunk that we process contains less dicts (e.g. 5), we will still update the progress bar with 10 and end up showing a total that is higher than the actual number of dicts we processed (+5).
Came up in https://github.com/deepset-ai/haystack/issues/27 

I am also adding the filename of the current dataset to  the description of the progress bar 

