### PR TITLE
Fix serialization for saving train checkpoints

### DIFF
--- a/farm/train.py
+++ b/farm/train.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tqdm import tqdm
 import numpy
 import shutil
+import dill
 
 from farm.utils import MLFlowLogger as MlLogger
 from farm.utils import GracefulKiller
@@ -460,6 +461,7 @@ class Trainer:
                 "cuda_rng_state": torch.cuda.get_rng_state(),
             },
             checkpoint_path / "trainer",
+            pickle_module=dill,
         )
 
         checkpoint_name = f"epoch_{self.from_epoch}_step_{self.from_step}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ flask-restplus
 flask-cors
 # optional: for inference with fasttext
 #fasttext==0.9.1
+dill # pickle extension for (de-)serialization


### PR DESCRIPTION
With #220, a lambda function for loss aggregation got added in the `AdaptiveModel`  that breaks the pickling of its instance objects. This causes an error when `torch.save()` is executed while saving a Train checkpoint.

This PR introduces `dill`, an extension of Python's standard pickling module that supports serialization and de-serialization of lambdas and other exotic types. `torch.save()` allows specifying the pickling module to use when saving objects.