### PR TITLE
Implement __len__()  for StreamingDataSilo

### DIFF
--- a/examples/train_from_scratch.py
+++ b/examples/train_from_scratch.py
@@ -77,17 +77,11 @@ def train_from_scratch():
     )
 
     # 5. Create an optimizer
-
-    # calculate approx number of training batches for streaming data silo
-    total_lines = sum(1 for line in open(data_dir/train_filename))
-    empty_lines = sum(1 if line == "\n" else 0 for line in open(data_dir/train_filename))
-    n_batches = int((total_lines - (2 * empty_lines)) / batch_size)
-
     model, optimizer, lr_schedule = initialize_optimizer(
         model=model,
         learning_rate=learning_rate,
         schedule_opts={"name": "LinearWarmup", "warmup_proportion": warmup_proportion},
-        n_batches=n_batches,
+        n_batches=len(stream_data_silo.get_data_loader("train")),
         n_epochs=n_epochs,
         device=device,
         grad_acc_steps=8,

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -572,7 +572,15 @@ class _StreamingDataSet(IterableDataset):
         self.filepath = filepath
         self.dataloader_workers = dataloader_workers
 
+        # calculate number of samples for __len__()
+        total_lines = sum(1 for line in open(filepath))
+        empty_lines = sum(1 if line == "\n" else 0 for line in open(filepath))
+        self.n_samples = total_lines - (2 * empty_lines)
+
         self.file_to_dicts_generator = processor.file_to_dicts(filepath)
+
+    def __len__(self):
+        return self.n_samples
 
     def __iter__(self):
         #  With IterableDataset, the same __iter__ is copied over to the multiple workers of

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -573,8 +573,8 @@ class _StreamingDataSet(IterableDataset):
         self.dataloader_workers = dataloader_workers
 
         # calculate number of samples for __len__()
-        total_lines = sum(1 for line in open(filepath))
-        empty_lines = sum(1 if line == "\n" else 0 for line in open(filepath))
+        total_lines = sum(1 for line in open(filepath, encoding="utf-8"))
+        empty_lines = sum(1 if line == "\n" else 0 for line in open(filepath, encoding="utf-8"))
         self.n_samples = total_lines - (2 * empty_lines)
 
         self.file_to_dicts_generator = processor.file_to_dicts(filepath)

--- a/farm/data_handler/dataloader.py
+++ b/farm/data_handler/dataloader.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 from torch.utils.data import DataLoader, Dataset, Sampler
 import torch
 
@@ -63,6 +65,14 @@ class NamedDataLoader(DataLoader):
             pin_memory=pin_memory,
             num_workers=num_workers,
         )
+
+    def __len__(self):
+        if type(self.dataset).__name__ == "_StreamingDataSet":
+            num_samples = len(self.dataset)
+            num_batches = ceil(num_samples / self.dataset.batch_size)
+            return num_batches
+        else:
+            return super().__len__()
 
 
 def covert_dataset_to_dataloader(dataset, sampler, batch_size):


### PR DESCRIPTION
The `StreamingDataSilo` uses PyTorch's `IterableDataSet` for yielding the datasets. The  `IterableDataSet` do not have an implementation for `__len__()`. However, in FARM, there are few instances where we use the length of datasets/dataloaders.

The PR adds `__len__()` on the `_StreamingDataSet`(total number of samples) and `NamedDataLoader`(total number of batches). This makes the behaviour of calling `len()` on  the `StreamingDataSilo` consistent with that of `DataSilo`.