### PR TITLE
Fix Train Step calculations for Checkpointing

### DIFF
--- a/farm/train.py
+++ b/farm/train.py
@@ -166,7 +166,7 @@ class Trainer:
                checkpoint, it is used to fast-forward training to the last step in the checkpoint.
         :type from_step: int
         :param global_step: the global step number across the training epochs.
-        :type global_step
+        :type global_step: int
         """
 
         self.model = model


### PR DESCRIPTION
Currently, the checkpointing during training is implemented at the beginning of the train loop. This causes a training step overlap. For instance, consider a case when `checkpoint_every` is set to 100 and a checkpoint is saved at step 300. Then, a training resumed from the saved checkpoint will start at step 300, causing step 300 to be executed twice.

This PR moves the checkpoint at the end of the training loop. Thus, when the training resumes from a checkpoint saved at step 300, it'd start from step 301.