### PR TITLE
Fix epoch number for saving a training checkpoint

### DIFF
--- a/farm/train.py
+++ b/farm/train.py
@@ -224,6 +224,7 @@ class Trainer:
         resume_from_step = self.from_step
 
         for epoch in range(self.from_epoch, self.epochs):
+            self.from_epoch = epoch
             train_data_loader = self.data_silo.get_data_loader("train")
             progress_bar = tqdm(train_data_loader)
             for step, batch in enumerate(progress_bar):
@@ -283,7 +284,6 @@ class Trainer:
                 if self.checkpoint_every and step % self.checkpoint_every == 0:
                     self._save()
 
-            self.from_epoch = epoch
             if do_stopping:
                 break
 


### PR DESCRIPTION
`Trainer` uses `self.from_epoch` to get the current epoch number when saving a checkpoint.

Currently, `from_epoch` gets updated at the end of the train loop, thus it lacks behind by 1. 

This PR makes a change to update the `from_epoch` at the beginning of the train loop.