### PR TITLE
Add ONNX support for Question Answering

### DIFF
--- a/examples/onnx_question_answering.py
+++ b/examples/onnx_question_answering.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from farm.infer import Inferencer
+from farm.modeling.adaptive_model import AdaptiveModel
+
+
+def onnx_runtime_example():
+    """
+    This example converts a Question Answering FARM AdaptiveModel
+    to ONNX format and uses ONNX Runtime for doing Inference.
+    """
+
+    device = "cpu"
+    model_name_or_path = "deepset/bert-base-cased-squad2"
+    onnx_model_export_path = Path("./onnx-export")
+
+    model = AdaptiveModel.convert_from_transformers(model_name_or_path, device=device, task_type="question_answering")
+    model.convert_to_onnx(onnx_model_export_path)
+
+    inferencer = Inferencer.load(model_name_or_path=onnx_model_export_path)
+
+    qa_input = [
+        {
+            "qas": ["Who counted the game among the best ever made?"],
+            "context": "Twilight Princess was released to universal critical acclaim and commercial success. "
+            "It received perfect scores from major publications such as 1UP.com, Computer and Video Games, "
+            "Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators "
+            "GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii "
+            "version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called "
+            "it one of the greatest games ever created.",
+        }
+    ]
+
+    results = inferencer.inference_from_dicts(qa_input)
+    print(results)
+
+
+if __name__ == "__main__":
+    onnx_runtime_example()

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -12,7 +12,7 @@ from farm.data_handler.dataloader import NamedDataLoader
 from farm.data_handler.processor import Processor, InferenceProcessor, SquadProcessor, NERProcessor, TextClassificationProcessor
 from farm.data_handler.utils import grouper
 from farm.modeling.tokenization import Tokenizer
-from farm.modeling.adaptive_model import AdaptiveModel
+from farm.modeling.adaptive_model import AdaptiveModel, BaseAdaptiveModel
 from farm.utils import initialize_device_settings
 from farm.utils import set_all_seeds, calc_chunksize, log_ascii_workers
 
@@ -75,7 +75,7 @@ class Inferencer:
         self.model.eval()
         self.batch_size = batch_size
         self.device = device
-        self.language = self.model.language_model.language
+        self.language = self.model.get_language()
         # TODO adjust for multiple prediction heads
         if len(self.model.prediction_heads) == 1:
             self.prediction_type = self.model.prediction_heads[0].model_type
@@ -134,7 +134,7 @@ class Inferencer:
 
         # a) either from local dir
         if os.path.exists(model_name_or_path):
-            model = AdaptiveModel.load(model_name_or_path, device, strict=strict)
+            model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=device, strict=strict)
             if task_type == "embeddings":
                 processor = InferenceProcessor.load_from_dir(model_name_or_path)
             else:

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 
 class Inferencer:
     """
-    Loads a saved AdaptiveModel from disk and runs it in inference mode. Can be used for a model with prediction head (down-stream predictions) and without (using LM as embedder).
+    Loads a saved AdaptiveModel/ONNXAdaptiveModel from disk and runs it in inference mode. Can be used for a
+    model with prediction head (down-stream predictions) and without (using LM as embedder).
 
     Example usage:
 

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -641,7 +641,15 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
 
 
 class ONNXAdaptiveModel(BaseAdaptiveModel):
-    def __init__(self, onnx_session, prediction_heads, device, language):
+    """
+    Implementation of ONNX Runtime for Inference of ONNX Models. This class is compatible with the FARM Inferencer.
+
+    To convert an existing FARM AdaptiveModel(PyTorch) to ONNX, use AdaptiveModel.convert_to_onnx().
+    """
+    def __init__(self, onnx_session, prediction_heads, language, device="cpu"):
+        if str(onnxruntime.get_device()).lower() != str(device).lower():
+            raise Exception(f"Device {device} not available for Inference. For CPU, run pip install onnxruntime and"
+                            f"for GPU run pip install onnxruntime-gpu")
         self.onnx_session = onnx_session
         self.prediction_heads = prediction_heads
         self.device = device
@@ -673,7 +681,7 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
             model_config = json.load(f)
             language = model_config["language"]
 
-        return cls(onnx_session, prediction_heads, device, language)
+        return cls(onnx_session, prediction_heads, language, device)
 
     def forward(self, **kwargs):
         """

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -656,9 +656,12 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
 
 class ONNXAdaptiveModel(BaseAdaptiveModel):
     """
-    Implementation of ONNX Runtime for Inference of ONNX Models. This class is compatible with the FARM Inferencer.
+    Implementation of ONNX Runtime for Inference of ONNX Models.
 
-    To convert an existing FARM AdaptiveModel(PyTorch) to ONNX, use AdaptiveModel.convert_to_onnx().
+    Existing PyTorch based FARM AdaptiveModel can be converted to ONNX format using AdpativeModel.convert_to_onnx().
+    The conversion is currently only implemented for Question Answering Models.
+
+    For inference, this class is compatible with the FARM Inferencer.
     """
     def __init__(self, onnx_session, prediction_heads, language, device="cpu"):
         if str(onnxruntime.get_device()).lower() != str(device).lower():
@@ -684,6 +687,8 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
         prediction_heads = []
         ph_output_type = []
         for config_file in ph_config_files:
+            # ONNX Model doesn't need have a separate neural network for PredictionHead. It only uses the
+            # instance methods of PredictionHead class, so, we load with the load_weights param as False.
             head = PredictionHead.load(config_file, load_weights=False)
             # # set shared weights between LM and PH
             # if type(head) == BertLMHead:

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -94,7 +94,7 @@ class PredictionHead(nn.Module):
         self.config = config
 
     @classmethod
-    def load(cls, config_file, strict=True):
+    def load(cls, config_file, strict=True, load_weights=True):
         """
         Loads a Prediction Head. Infers the class of prediction head from config_file.
 
@@ -109,9 +109,10 @@ class PredictionHead(nn.Module):
         """
         config = json.load(open(config_file))
         prediction_head = cls.subclasses[config["name"]](**config)
-        model_file = cls._get_model_file(config_file=config_file)
-        logger.info("Loading prediction head from {}".format(model_file))
-        prediction_head.load_state_dict(torch.load(model_file, map_location=torch.device("cpu")), strict=strict)
+        if load_weights:
+            model_file = cls._get_model_file(config_file=config_file)
+            logger.info("Loading prediction head from {}".format(model_file))
+            prediction_head.load_state_dict(torch.load(model_file, map_location=torch.device("cpu")), strict=strict)
         return prediction_head
 
     def logits_to_loss(self, logits, labels):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ flask-cors
 # optional: for inference with fasttext
 #fasttext==0.9.1
 dill # pickle extension for (de-)serialization
+onnxruntime  # Inference with ONNX models. Install onnxruntime-gpu for Inference on GPUs


### PR DESCRIPTION
This PR adds conversion of PyTorch model to ONNX and support for Inference using [ONNX Runtime](https://github.com/microsoft/onnxruntime).

For converting a PyTorch based Question Answering AdaptiveModel, use `AdpativeModel.convert_to_onnx()`. It exports a converted ONNX model to the supplied path.

The exported ONNX model can be used with the FARM `Inferencer`. Under the hood, `ONNXAdaptiveModel` class implements ONNX Runtime for the forward pass on the model.

This example contains a basic guide for conversion to ONNX and Inference on the converted model.

This [thread](https://github.com/deepset-ai/haystack/issues/39) has preliminary benchmarks for inference with ONNX Runtime.