### PR TITLE
Make extract_vectors more compatible to other inference types

### DIFF
--- a/examples/embeddings_extraction.py
+++ b/examples/embeddings_extraction.py
@@ -2,28 +2,6 @@ from farm.infer import Inferencer
 from farm.utils import set_all_seeds
 from pathlib import Path
 
-def embeddings_extraction_old():
-    set_all_seeds(seed=42)
-    batch_size = 32
-    use_gpu = False
-    lang_model = "bert-base-german-cased"
-    # or local path:
-    # lang_model = Path("../saved_models/farm-bert-base-cased-squad2")
-
-    # Input
-    basic_texts = [
-        {"text": "Schartau sagte dem Tagesspiegel, dass Fischer ein Idiot ist"},
-        {"text": "Martin Müller spielt Fussball"},
-    ]
-
-    # Load model, tokenizer and processor directly into Inferencer
-    model = Inferencer.load(lang_model, task_type="embeddings", gpu=use_gpu, batch_size=batch_size)
-
-    # Get embeddings for input text (you can vary the strategy and layer)
-    result = model.extract_vectors(dicts=basic_texts, extraction_strategy="cls_token", extraction_layer=-1)
-    print(result)
-
-
 def embeddings_extraction():
     set_all_seeds(seed=42)
     batch_size = 32
@@ -39,13 +17,11 @@ def embeddings_extraction():
     ]
 
     # Load model, tokenizer and processor directly into Inferencer
-    # model = Inferencer.load(lang_model, task_type="embeddings", gpu=use_gpu, batch_size=batch_size,
-    #                         extraction_strategy="cls_token", extraction_layer=-1)
-    model = Inferencer.load(lang_model, task_type="embeddings", gpu=use_gpu, batch_size=batch_size)
+    model = Inferencer.load(lang_model, task_type="embeddings", gpu=use_gpu, batch_size=batch_size,
+                            extraction_strategy="reduce_mean", extraction_layer=-2)
 
     # Get embeddings for input text (you can vary the strategy and layer)
-    # result = model.inference_from_dicts(dicts=basic_texts, max_processes=1)
-    result = model.extract_vectors(dicts=basic_texts, max_processes=1)
+    result = model.inference_from_dicts(dicts=basic_texts, max_processes=1)
     print(result)
 
 if __name__ == "__main__":

--- a/examples/onnx_question_answering.py
+++ b/examples/onnx_question_answering.py
@@ -31,7 +31,7 @@ def onnx_runtime_example():
         }
     ]
 
-    results = inferencer.inference_from_dicts(qa_input, rest_api_schema=True)
+    results = inferencer.inference_from_dicts(qa_input)
     print(results)
 
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -98,14 +98,9 @@ class Inferencer:
             self.model.language_model.extraction_layer = extraction_layer
             self.model.language_model.extraction_strategy = extraction_strategy
 
-        # TODO adjust for multiple prediction heads
-        # TODO check if still used in API to determine model type
-        if len(self.model.prediction_heads) == 1:
-            self.prediction_type = self.model.prediction_heads[0].model_type
-        elif len(self.model.prediction_heads) == 0:
-            self.prediction_type = "embeddings"
+        # TODO add support for multiple prediction heads
 
-        self.name = name if name != None else f"anonymous-{self.prediction_type}"
+        self.name = name if name != None else f"anonymous-{self.task_type}"
         self.return_class_probs = return_class_probs
 
         model.connect_heads_with_processor(processor.tasks, require_labels=False)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -271,7 +271,7 @@ class Inferencer:
             # Get us some workers (i.e. processes)
             p = mp.Pool(processes=num_cpus_used)
             logger.info(
-                f"Got ya {num_cpus_used} parallel workers to do inference on {len(dicts)}dicts (chunksize = {multiprocessing_chunk_size})..."
+                f"Got ya {num_cpus_used} parallel workers to do inference on {len(dicts)} dicts (chunksize = {multiprocessing_chunk_size})..."
             )
             log_ascii_workers(num_cpus_used, logger)
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -37,8 +37,8 @@ class Inferencer:
        model = Inferencer.load(your_model_dir)
        model.inference_from_dicts(dicts=basic_texts)
        # LM embeddings
-       model.extract_vectors(dicts=basic_texts)
-
+       model = Inferencer.load(your_model_dir, extraction_strategy="cls_token", extraction_layer=-1)
+       model.inference_from_dicts(dicts=basic_texts)
     """
 
     def __init__(
@@ -71,6 +71,11 @@ class Inferencer:
         :type name: string
         :param return_class_probs: either return probability distribution over all labels or the prob of the associated label
         :type return_class_probs: bool
+        :param extraction_strategy: Strategy to extract vectors. Choices: 'cls_token' (sentence vector), 'reduce_mean'
+                               (sentence vector), reduce_max (sentence vector), 'per_token' (individual token vectors)
+        :type extraction_strategy: str
+        :param extraction_layer: number of layer from which the embeddings shall be extracted. Default: -1 (very last layer).
+        :type extraction_layer: int
         :return: An instance of the Inferencer.
 
         """
@@ -87,10 +92,9 @@ class Inferencer:
 
         if task_type == "embeddings":
             if not extraction_layer or not extraction_strategy:
-                if not hasattr(self.model.language_model, "extraction_layer") or not hasattr(self.model.language_model, "extraction_strategy"):
-                    raise ValueError("You need to set both args `extraction_layer` and `extraction_strategy`")
+                    logger.warning("Using task_type='embeddings', but couldn't find one of the args `extraction_layer` and `extraction_strategy`. "
+                                   "Since FARM 0.4.2, you set both when initializing the Inferencer and then call inferencer.inference_from_dicts() instead of inferencer.extract_vectors()")
             self.model.prediction_heads = torch.nn.ModuleList([])
-            #self.model.skip_heads = True
             self.model.language_model.extraction_layer = extraction_layer
             self.model.language_model.extraction_strategy = extraction_strategy
 
@@ -144,6 +148,11 @@ class Inferencer:
         :type max_seq_len: int
         :param doc_stride: Only QA: When input text is longer than max_seq_len it gets split into parts, strided by doc_stride
         :type doc_stride: int
+        :param extraction_strategy: Strategy to extract vectors. Choices: 'cls_token' (sentence vector), 'reduce_mean'
+                               (sentence vector), reduce_max (sentence vector), 'per_token' (individual token vectors)
+        :type extraction_strategy: str
+        :param extraction_layer: number of layer from which the embeddings shall be extracted. Default: -1 (very last layer).
+        :type extraction_layer: int
         :return: An instance of the Inferencer.
 
         """

--- a/farm/inference_rest_api.py
+++ b/farm/inference_rest_api.py
@@ -42,10 +42,14 @@ class ModelListEndpoint(Resource):
         resp = []
 
         for idx, model in INFERENCERS.items():
+
+            #TODO UI still relies on the old prediction_type attribute, but we should switch this to inferencer.task_type
+            prediction_type = model.model.prediction_heads[0].model_type
+
             _res = {
                 "id": idx,
                 "name": model.name,
-                "prediction_type": model.prediction_type,
+                "prediction_type": prediction_type,
                 "language": model.language,
             }
             resp.append(_res)

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -275,9 +275,6 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         ph_output_type = []
         for config_file in ph_config_files:
             head = PredictionHead.load(config_file, strict=strict)
-            # # set shared weights between LM and PH
-            # if type(head) == BertLMHead:
-            #     head.set_shared_weights(language_model)
             prediction_heads.append(head)
             ph_output_type.append(head.ph_output_type)
 
@@ -362,7 +359,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         """
         all_preds = []
 
-        if len(self.prediction_heads) == 0 or self.disable_heads:
+        if len(self.prediction_heads) == 0:
             # just return LM output (e.g. useful for extracting embeddings at inference time)
             all_preds = self.language_model.formatted_preds(logits=logits, **kwargs)
         else:
@@ -719,9 +716,6 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
             # ONNX Model doesn't need have a separate neural network for PredictionHead. It only uses the
             # instance methods of PredictionHead class, so, we load with the load_weights param as False.
             head = PredictionHead.load(config_file, load_weights=False)
-            # # set shared weights between LM and PH
-            # if type(head) == BertLMHead:
-            #     head.set_shared_weights(language_model)
             prediction_heads.append(head)
             ph_output_type.append(head.ph_output_type)
 

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -239,8 +239,9 @@ class LanguageModel(nn.Module):
 
         # TODO catch error if self.extraction_strategy has not been set properly
 
-        sequence_output = logits[0]
-        pooled_output = logits[1]
+        # unpack the tuple from LM forward pass
+        sequence_output = logits[0][0]
+        pooled_output = logits[0][1]
 
         # aggregate vectors
         if self.extraction_strategy == "pooled":

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -253,8 +253,7 @@ class LanguageModel(nn.Module):
         :return: list of dicts containing preds, e.g. [{"context": "some text", "vec": [-0.01, 0.5 ...]}]
         """
 
-        if not hasattr(self.model.language_model, "extraction_layer") or not hasattr(self.model.language_model,
-                                                                                     "extraction_strategy"):
+        if not hasattr(self, "extraction_layer") or not hasattr(self, "extraction_strategy"):
             raise ValueError("`extraction_layer` or `extraction_strategy` not specified for LM. "
                              "Make sure to set both, e.g. via Inferencer(extraction_strategy='cls_token', extraction_layer=-1)`")
 

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -236,8 +236,27 @@ class LanguageModel(nn.Module):
 
     def formatted_preds(self, logits, samples, ignore_first_token=True,
                         padding_mask=None, **kwargs):
+        """
+        Extracting vectors from language model (e.g. for extracting sentence embeddings).
+        Different pooling strategies and layers are available and will be determined from the object attributes
+        `extraction_layer` and `extraction_strategy`. Both should be set via the Inferencer:
+        Example:  Inferencer(extraction_strategy='cls_token', extraction_layer=-1)
 
-        # TODO catch error if self.extraction_strategy has not been set properly
+        :param logits: Tuple of (sequence_output, pooled_output) from the language model.
+                       Sequence_output: one vector per token, pooled_output: one vector for whole sequence
+        :param samples: For each item in logits we need additional meta information to format the prediction (e.g. input text).
+                        This is created by the Processor and passed in here from the Inferencer.
+        :param ignore_first_token: Whether to include the first token for pooling operations (e.g. reduce_mean).
+                                   Many models have here a special token like [CLS] that you don't want to include into your average of token embeddings.
+        :param padding_mask: Mask for the padding tokens. Those will also not be included in the pooling operations to prevent a bias by the number of padding tokens.
+        :param kwargs: kwargs
+        :return: list of dicts containing preds, e.g. [{"context": "some text", "vec": [-0.01, 0.5 ...]}]
+        """
+
+        if not hasattr(self.model.language_model, "extraction_layer") or not hasattr(self.model.language_model,
+                                                                                     "extraction_strategy"):
+            raise ValueError("`extraction_layer` or `extraction_strategy` not specified for LM. "
+                             "Make sure to set both, e.g. via Inferencer(extraction_strategy='cls_token', extraction_layer=-1)`")
 
         # unpack the tuple from LM forward pass
         sequence_output = logits[0][0]

--- a/test/test_doc_classification_distilbert.py
+++ b/test/test_doc_classification_distilbert.py
@@ -18,7 +18,7 @@ def test_doc_classification(caplog):
     caplog.set_level(logging.CRITICAL)
 
     set_all_seeds(seed=42)
-    device, n_gpu = initialize_device_settings(use_cuda=True)
+    device, n_gpu = initialize_device_settings(use_cuda=False)
     n_epochs = 1
     batch_size = 1
     evaluate_every = 2


### PR DESCRIPTION
So far `Inferencer.extract_vectors()` was treated very differently to other inference types. 
While this was simpler in the implementation it also caused confusion and prevented us to reuse multiproc, inference from file etc.

Let's try to make this more compatible to the other inference modes.