### PR TITLE
Add metric to text_pair_classification example

### DIFF
--- a/examples/text_pair_classification.py
+++ b/examples/text_pair_classification.py
@@ -43,6 +43,7 @@ def text_pair_classification():
     # The TextPairClassificationProcessor expects a csv with columns called "text', "text_b" and "label"
     processor = TextPairClassificationProcessor(tokenizer=tokenizer,
                                                 label_list=label_list,
+                                                metric="f1_macro",
                                                 max_seq_len=128,
                                                 dev_filename="dev.tsv",
                                                 test_filename=None,


### PR DESCRIPTION
Adds a metric parameter to the TextPairClassificationProcessor so that it is initialized with a task and runs properly.