### PR TITLE
Add preprocessed CORD-19 dataset

### DIFF
--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -28,6 +28,7 @@ DOWNSTREAM_TASK_MAP = {
     "conll03entrain": "https://raw.githubusercontent.com/synalp/NER/master/corpus/CoNLL-2003/eng.train",
     "conll03endev": "https://raw.githubusercontent.com/synalp/NER/master/corpus/CoNLL-2003/eng.testa",
     "conll03entest": "https://raw.githubusercontent.com/synalp/NER/master/corpus/CoNLL-2003/eng.testb",
+    "cord_19": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/cord_19.tar.gz",
     "lm_finetune_nips": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/lm_finetune_nips.tar.gz",
     "toxic-comments": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/toxic-comments.tar.gz",
     'cola': "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/cola.tar.gz",


### PR DESCRIPTION
This adds a link to the CORD-19 dataset (https://www.kaggle.com/allen-institute-for-ai/CORD-19-research-challenge) for Language Model Finetuning. To automatically download the dataset, just set data_dir=Path("cord_19") in the Processor