### PR TITLE
Upgrade to Transformers 2.7.0

### DIFF
--- a/farm/data_handler/input_features.py
+++ b/farm/data_handler/input_features.py
@@ -47,7 +47,8 @@ def sample_to_features_text(
         tokens_b,
         add_special_tokens=True,
         max_length=max_seq_len,
-        truncation_strategy='do_not_truncate'
+        truncation_strategy='do_not_truncate',
+        return_token_type_ids=True
     )
 
     input_ids, segment_ids = inputs["input_ids"], inputs["token_type_ids"]
@@ -143,9 +144,9 @@ def samples_to_features_ner(
                                    add_special_tokens=True,
                                    max_length=max_seq_len,
                                    truncation_strategy='do_not_truncate', # We've already truncated our tokens before
-                                   return_special_tokens_mask=True
-
-    )
+                                   return_special_tokens_mask=True,
+                                   return_token_type_ids=True
+                                   )
 
     input_ids, segment_ids, special_tokens_mask = inputs["input_ids"], inputs["token_type_ids"], inputs["special_tokens_mask"]
 
@@ -259,7 +260,8 @@ def samples_to_features_bert_lm(sample, max_seq_len, tokenizer, next_sent_pred=T
                                    max_length=max_seq_len,
                                    truncation_strategy='do_not_truncate',
                                    # We've already truncated our tokens before
-                                   return_special_tokens_mask=True
+                                   return_special_tokens_mask=True,
+                                   return_token_type_ids=True
                                    )
 
     input_ids, segment_ids, special_tokens_mask = inputs["input_ids"], inputs["token_type_ids"], inputs[
@@ -350,6 +352,7 @@ def sample_to_features_squad(sample, tokenizer, max_seq_len, max_answers=6):
                                     add_special_tokens=True,
                                     max_length=None,
                                     truncation_strategy='only_second',
+                                    return_token_type_ids=True,
                                     return_tensors=None)
     input_ids = encoded["input_ids"]
     segment_ids = encoded["token_type_ids"]

--- a/farm/modeling/tokenization.py
+++ b/farm/modeling/tokenization.py
@@ -149,10 +149,14 @@ def _words_to_tokens(words, word_offsets, tokenizer):
     start_of_word = []
     for w, w_off in zip(words, word_offsets):
         # Get (subword) tokens of single word.
+
+        # empty / pure whitespace
+        if len(w) == 0:
+          continue
         # For the first word of a text: we just call the regular tokenize function.
         # For later words: we need to call it with add_prefix_space=True to get the same results with roberta / gpt2 tokenizer
         # see discussion here. https://github.com/huggingface/transformers/issues/1196
-        if len(tokens) == 0:
+        elif len(tokens) == 0:
             tokens_word = tokenizer.tokenize(w)
         else:
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sklearn
 seqeval
 mlflow==1.0.0
 # huggingface repository
-transformers==2.4.0
+transformers==2.7.0
 # accessing dictionary elements with dot notation
 dotmap==1.3.0
 # for inference-rest-apis


### PR DESCRIPTION
Required changes:

1. Add `return_token_type_ids=True` to our calls to `tokenizer.encode_plus()`. 
> Encoding methods now output only model-specific inputs
Models such as DistilBERT and RoBERTa do not make use of token type IDs. These inputs are not returned by the encoding methods anymore, except if explicitly mentioned during the tokenizer initialization.

2. Catching empty strings before tokenizer call as new Transformers' tokenizers fail for empty strings (good that we had some tests on edge cases here :smiley: )

