### PR TITLE
Fix ONNX device assertion for GPU and update session optimizations

### DIFF
--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -4,7 +4,7 @@ import logging
 import os
 from pathlib import Path
 
-import psutil
+import multiprocessing
 import numpy
 import onnxruntime
 import torch
@@ -685,13 +685,13 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
     """
     Implementation of ONNX Runtime for Inference of ONNX Models.
 
-    Existing PyTorch based FARM AdaptiveModel can be converted to ONNX format using AdpativeModel.convert_to_onnx().
+    Existing PyTorch based FARM AdaptiveModel can be converted to ONNX format using AdaptiveModel.convert_to_onnx().
     The conversion is currently only implemented for Question Answering Models.
 
     For inference, this class is compatible with the FARM Inferencer.
     """
-    def __init__(self, onnx_session, prediction_heads, language, device="cpu"):
-        if device == "cuda" and onnxruntime.get_device() != "gpu":
+    def __init__(self, onnx_session, prediction_heads, language, device):
+        if str(device) == "cuda" and onnxruntime.get_device() != "GPU":
             raise Exception(f"Device {device} not available for Inference. For CPU, run pip install onnxruntime and"
                             f"for GPU run pip install onnxruntime-gpu")
         self.onnx_session = onnx_session
@@ -705,7 +705,7 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
         # Set graph optimization level to ORT_ENABLE_EXTENDED to enable bert optimization.
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
         # Use OpenMP optimizations. Only useful for CPU, has little impact for GPUs.
-        sess_options.intra_op_num_threads = psutil.cpu_count(logical=True)
+        sess_options.intra_op_num_threads = multiprocessing.cpu_count()
         onnx_session = onnxruntime.InferenceSession(str(load_dir / "model.onnx"), sess_options)
 
         # Prediction heads


### PR DESCRIPTION
This PR address the following:

- fix for device assertion when loading an ONNX model on a GPU
- remove the creation of an optimization graph during session creation as it's only meant for debugging
- add open MP optimization for inference on CPU