### PR TITLE
Add Handling of Out of Vocabulary Chars

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -479,6 +479,8 @@ class TextClassificationProcessor(Processor):
     def _dict_to_samples(self, dictionary: dict, **kwargs) -> [Sample]:
         # this tokenization also stores offsets and a start_of_word mask
         tokenized = tokenize_with_metadata(dictionary["text"], self.tokenizer)
+        if len(tokenized["tokens"]) == 0:
+            return []
         # truncate tokens, offsets and start_of_word to max_seq_len that can be handled by the model
         for seq_name in tokenized.keys():
             tokenized[seq_name], _, _ = truncate_sequences(seq_a=tokenized[seq_name], seq_b=None, tokenizer=self.tokenizer,
@@ -516,6 +518,8 @@ class TextPairClassificationProcessor(TextClassificationProcessor):
     def _dict_to_samples(self, dictionary: dict, **kwargs) -> [Sample]:
         tokenized_a = tokenize_with_metadata(dictionary["text"], self.tokenizer)
         tokenized_b = tokenize_with_metadata(dictionary["text_b"], self.tokenizer)
+        if len(tokenized_a["tokens"]) == 0 or len(tokenized_b["tokens"]) == 0:
+            return []
         tokenized = {"tokens": tokenized_a["tokens"],
                      "tokens_b": tokenized_b["tokens"]}
         tokenized["tokens"], tokenized["tokens_b"], _ = truncate_sequences(seq_a=tokenized["tokens"],
@@ -681,6 +685,8 @@ class NERProcessor(Processor):
     def _dict_to_samples(self, dictionary: dict, **kwargs) -> [Sample]:
         # this tokenization also stores offsets, which helps to map our entity tags back to original positions
         tokenized = tokenize_with_metadata(dictionary["text"], self.tokenizer)
+        if len(tokenized["tokens"]) == 0:
+            return []
         # truncate tokens, offsets and start_of_word to max_seq_len that can be handled by the model
         for seq_name in tokenized.keys():
             tokenized[seq_name], _, _ = truncate_sequences(seq_a=tokenized[seq_name], seq_b=None, tokenizer=self.tokenizer,
@@ -1148,6 +1154,8 @@ class RegressionProcessor(Processor):
     def _dict_to_samples(self, dictionary: dict, **kwargs) -> [Sample]:
         # this tokenization also stores offsets
         tokenized = tokenize_with_metadata(dictionary["text"], self.tokenizer)
+        if len(tokenized["tokens"]) == 0:
+            return []
         # truncate tokens, offsets and start_of_word to max_seq_len that can be handled by the model
         for seq_name in tokenized.keys():
             tokenized[seq_name], _, _ = truncate_sequences(seq_a=tokenized[seq_name], seq_b=None,

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -277,6 +277,7 @@ class Processor(ABC):
             except:
                 logger.error(f"Could not create sample(s) from this dict: \n {basket.raw}")
                 raise
+        self.baskets = [b for b in self.baskets if len(b.samples) > 0]
 
     def _featurize_samples(self):
         for basket in self.baskets:
@@ -802,6 +803,8 @@ class BertStyleLMProcessor(Processor):
                 tokenized["text_b"] = tokenize_with_metadata(
                     text_b, self.tokenizer
                 )
+                if len(tokenized["text_a"]["tokens"]) == 0 or len(tokenized["text_b"]["tokens"]) == 0:
+                    continue
                 # truncate to max_seq_len
                 for seq_name in ["tokens", "offsets", "start_of_word"]:
                     tokenized["text_a"][seq_name], tokenized["text_b"][seq_name], _ = truncate_sequences(
@@ -822,6 +825,8 @@ class BertStyleLMProcessor(Processor):
                 tokenized["text_a"] = tokenize_with_metadata(
                     text_a, self.tokenizer
                 )
+                if len(tokenized["text_a"]["tokens"]) == 0:
+                    continue
                 # truncate to max_seq_len
                 for seq_name in ["tokens", "offsets", "start_of_word"]:
                     tokenized["text_a"][seq_name], _, _ = truncate_sequences(


### PR DESCRIPTION
This pull request adds handling of Out of Vocabulary Chars. If the tokenization of an input sequence returns no tokens, then the sample is thrown out. If this results in an empty SampleBasket, the Basket is removed. Note that this means that some basket ids may be missing

e.g.
self.baskets = [Basket(id=0), Basket(id=1), Basket(id=2), Basket(id=4)]

This should fix #298 