### PR TITLE
Transfer logits to the torch device after ONNX forward pass

### DIFF
--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -739,7 +739,7 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
                 'segment_ids': numpy.ascontiguousarray(kwargs['segment_ids'].cpu().numpy()),
             }
             res = self.onnx_session.run(None, input_to_onnx)
-            logits = [torch.from_numpy(res[0])]
+            logits = [torch.from_numpy(res[0]).to(self.device)]
 
         return logits
 


### PR DESCRIPTION
During inference, a `forward()` pass on the model gets logits, that are then passed to the model's `logits_to_preds()` method. The `logits_to_preds()` computation happens on the device where logits are present.

The result of the ONNX forward pass gets transferred to the CPU. Thus, `logits_to_preds()` was not utilizing the GPU, slowing the inference. This PR ensures that the logits are moved back to the GPU(if available). 

Ideally, we would want to avoid copying data back and forth between CPU and GPU. There's a related open [issue](https://github.com/microsoft/onnxruntime/issues/1621).