### PR TITLE
Less verbosity, Fix which Samples and Baskets being Thrown Away

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -278,7 +278,8 @@ class Processor(ABC):
                 logger.error(f"Could not create sample(s) from this dict: \n {basket.raw}")
                 raise
         baskets_to_remove = [b.id for b in self.baskets if len(b.samples) == 0]
-        logger.warning(f"Baskets with the following ids have been removed because they have no Samples: {baskets_to_remove}")
+        if baskets_to_remove:
+            logger.warning(f"Baskets with the following ids have been removed because they have no Samples: {baskets_to_remove}")
         self.baskets = [b for b in self.baskets if len(b.samples) > 0]
 
     def _featurize_samples(self):
@@ -827,11 +828,11 @@ class BertStyleLMProcessor(Processor):
                 if len(tokenized["text_a"]["tokens"]) == 0:
                     logger.warning(
                         f"The following text could not be tokenized, likely because it contains a character that the tokenizer does not recognize: {text_a}")
-                    return []
+                    continue
                 if len(tokenized["text_b"]["tokens"]) == 0:
                     logger.warning(
                         f"The following text could not be tokenized, likely because it contains a character that the tokenizer does not recognize: {text_b}")
-                    return []
+                    continue
 
                 # truncate to max_seq_len
                 for seq_name in ["tokens", "offsets", "start_of_word"]:


### PR DESCRIPTION
This PR removes a warning about removing baskets even when no baskets are thrown away.

This also fixes an issue where a whole Basket was thrown away if just one of its Samples was thrown away