### PR TITLE
Add streaming mode for Inferencer

### DIFF
--- a/examples/streaming_inference.py
+++ b/examples/streaming_inference.py
@@ -21,7 +21,7 @@ def streaming_inference_example():
 
 def sample_dicts_generator():
     """
-    This is a sample dicts generator. Some example real world use-cases
+    This is a sample dicts generator. Some exemplary use cases:
 
     * read chunks of text from large files iteratively and generate inference predictions
     * connect with external datasources, eg, a Elasticsearch Scroll API that reads all documents from a given index

--- a/examples/streaming_inference.py
+++ b/examples/streaming_inference.py
@@ -1,0 +1,48 @@
+from farm.infer import Inferencer
+
+
+def streaming_inference_example():
+    """
+    The FARM Inferencer has a high performance non-blocking streaming mode for large scale inference use cases. With
+    this mode, the dicts parameter can optionally be a Python generator object that yield dicts, thus avoiding loading
+    dicts in memory. The inference_from_dicts() method returns a generator that yield predictions. To use streaming,
+    set the streaming param to True and determine optimal multiprocessing_chunksize by performing speed benchmarks.
+    """
+
+    model_name_or_path = "deepset/bert-base-cased-squad2"
+    inferencer = Inferencer.load(model_name_or_path=model_name_or_path, task_type="question_answering")
+
+    dicts = sample_dicts_generator()  # it can be a list of dicts or a generator object
+    results = inferencer.inference_from_dicts(dicts, num_processes=8, streaming=True, multiprocessing_chunksize=20)
+
+    for prediction in results:  # results is a generator object that yields predictions
+        print(prediction)
+
+
+def sample_dicts_generator():
+    """
+    This is a sample dicts generator. Some example real world use-cases
+
+    * read chunks of text from large files iteratively and generate inference predictions
+    * connect with external datasources, eg, a Elasticsearch Scroll API that reads all documents from a given index
+    * building a streaming microservice that reads from Kafka
+
+    :return: a generator that yield dicts
+    :rtype: iter
+    """
+    qa_input = {
+        "qas": ["Who counted the game among the best ever made?"],
+        "context": "Twilight Princess was released to universal critical acclaim and commercial success. "
+                   "It received perfect scores from major publications such as 1UP.com, Computer and Video Games, "
+                   "Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators "
+                   "GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii "
+                   "version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called "
+                   "it one of the greatest games ever created.",
+    }
+
+    for i in range(100000):
+        yield qa_input
+
+
+if __name__ == "__main__":
+    streaming_inference_example()

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 from farm.data_handler.dataloader import NamedDataLoader
 from farm.data_handler.processor import Processor, BertStyleLMProcessor
-from farm.data_handler.utils import grouper, stream_grouper
+from farm.data_handler.utils import grouper
 from farm.utils import MLFlowLogger as MlLogger
 from farm.utils import log_ascii_workers, calc_chunksize
 from farm.utils import get_dict_checksum
@@ -591,18 +591,18 @@ class _StreamingDataSet(IterableDataset):
         #  a Dataloader. Hence, we need to configure the __iter__ to not yield duplicated data
         #  when more than 1 workers are used.
         #
-        #  To avoid duplicates, we need to split the input dicts between the workers. The
-        #  stream_grouper() converts a dict generator given as input and yields only the
+        #  To avoid duplicates, we need to split the input dicts between the workers.
+        #  The grouper() converts a dict generator given as input and yields only the
         #  dicts that are to be processed by the given worker_id.
         #
-        #  For instance, consider input as [dictA, dictB, dictC, ...], then the stream_grouper
+        #  For instance, consider input as [dictA, dictB, dictC, ...], then the grouper
         #  (with n=2) will return, [[dictA, dictB], [dictE, dictF] ...] for worker 1 and
         #  [[dictC, dictD], [dictG, dictH] ...] for worker 2.
 
         if self.dataloader_workers > 1:
             worker_info = torch.utils.data.get_worker_info()
             worker_id = worker_info.id
-            dicts = stream_grouper(
+            dicts = grouper(
                 self.file_to_dicts_generator, n=10, worker_id=worker_id, total_workers=self.dataloader_workers
             )
         else:

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -537,18 +537,19 @@ def is_json(x):
     except:
         return False
 
-def grouper(iterable, n):
+
+def grouper(iterable, n, worker_id=0, total_workers=1):
     """
+    Split an iterable into a list of n-sized chunks. Each element in the chunk is a tuple of (index_num, element).
+
+    Example:
+
     >>> list(grouper('ABCDEFG', 3))
     [[(0, 'A'), (1, 'B'), (2, 'C')], [(3, 'D'), (4, 'E'), (5, 'F')], [(6, 'G')]]
-    """
-    iterable = iter(enumerate(iterable))
-    return iter(lambda: list(islice(iterable, n)), [])
 
 
-def stream_grouper(iterable, n, worker_id, total_workers):
-    """
-    This method is an extension of grouper() for use with StreamingDataSilo.
+
+    Use with the StreamingDataSilo
 
     When StreamingDataSilo is used with multiple PyTorch DataLoader workers, the generator
     yielding dicts(that gets converted to datasets) is replicated across the workers.
@@ -599,6 +600,7 @@ def stream_grouper(iterable, n, worker_id, total_workers):
 
     iterable = iter(enumerate(iterable))
     iterable = get_iter_start_pos(iterable)
-    iterable = filter_elements_per_worker(iterable)
+    if total_workers > 1:
+        iterable = filter_elements_per_worker(iterable)
 
     return iter(lambda: list(islice(iterable, n)), [])

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -521,7 +521,7 @@ class Inferencer:
         return preds_all
 
     def extract_vectors(
-        self, dicts, extraction_strategy="cls_token", extraction_layer=-1, max_processes=1
+        self, dicts, extraction_strategy="cls_token", extraction_layer=-1, num_processes=None
     ):
         """
         Converts a text into vector(s) using the language model only (no prediction head involved).
@@ -537,8 +537,8 @@ class Inferencer:
         :type extraction_strategy: str
         :param extraction_layer: number of layer from which the embeddings shall be extracted. Default: -1 (very last layer).
         :type extraction_layer: int
-        :param max_processes: number of parallel processes for multiprocessing
-        :type max_processes: int
+        :param num_processes: number of parallel processes for multiprocessing
+        :type num_processes: int
         :return: dict of predictions
         """
 
@@ -547,7 +547,7 @@ class Inferencer:
         self.model.language_model.extraction_layer = extraction_layer
         self.model.language_model.extraction_strategy = extraction_strategy
 
-        return self.inference_from_dicts(dicts, rest_api_schema=False, max_processes=max_processes)
+        return self.inference_from_dicts(dicts, rest_api_schema=False, num_processes=num_processes)
 
 
 class FasttextInferencer:

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -278,7 +278,8 @@ class Inferencer:
         set the streaming param to True and determine optimal multiprocessing_chunksize by performing speed benchmarks.
 
 
-        :param dicts: Samples to run inference on provided as a list of dicts. One dict per sample.
+        :param dicts: Samples to run inference on provided as a list(or a generator object) of dicts.
+                      One dict per sample.
         :type dicts: iter(dict)
         :param rest_api_schema: Whether input dicts use the format that complies with the FARM REST API.
                                 Currently only used for QA to switch from squad to a more useful format in production.
@@ -339,7 +340,6 @@ class Inferencer:
             # return a generator object if streaming is enabled, else, cast the generator to a list.
             if not streaming and type(predictions) != list:
                 return list(predictions)
-                return list(itertools.chain(*predictions))
             else:
                 return predictions
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -225,46 +225,85 @@ class Inferencer:
         self.model.save(path)
         self.processor.save(path)
 
-    def inference_from_file(self, file, max_processes=128):
+    def inference_from_file(self, file, num_processes=None, multiprocessing_chunksize=None, streaming=False):
         """
         Run down-stream inference on samples created from an input file.
         The file should be in the same format as the ones used during training
-        (e.g. squad style for QA, tsv for doc classification ...) as the same processor will be used for conversion .
+        (e.g. squad style for QA, tsv for doc classification ...) as the same Processor will be used for conversion.
 
         :param file: path of the input file for Inference
         :type file: str
-        :param max_processes: the maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
-                              If you want to debug the Language Model, you might need to disable multiprocessing!
-        :type max_processes: int
+        :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
+                              multiprocessing. Set to None to let Inferencer determine optimum number. If you
+                              want to debug the Language Model, you might need to disable multiprocessing!
+        :type num_processes: int
+        :param multiprocessing_chunksize: number of dicts to put together in one chunk and feed to one process
+        :type multiprocessing_chunksize: int
+        :param streaming: return a Python generator object that yield results as they get computed, instead of
+                          blocking for all the results. To use streaming, the dicts parameter must be a generator
+                          and num_processes argument must be set. This mode can be useful to implement large scale
+                          non-blocking inference pipelines.
+        :type streaming: bool
+
+        :return: an iterator(list or generator) of predictions
+        :rtype: iter
         """
         dicts = self.processor.file_to_dicts(file)
-        preds_all = self.inference_from_dicts(dicts, rest_api_schema=False, max_processes=max_processes)
-        return preds_all
+        preds_all = self.inference_from_dicts(
+            dicts,
+            rest_api_schema=False,
+            num_processes=num_processes,
+            multiprocessing_chunksize=multiprocessing_chunksize,
+            streaming=streaming,
+        )
+        if streaming:
+            return preds_all
+        else:
+            return list(preds_all)
 
-    def inference_from_dicts(self, dicts, rest_api_schema=False, max_processes=128, min_chunksize=4):
+    def inference_from_dicts(
+        self, dicts, rest_api_schema=False, num_processes=None, multiprocessing_chunksize=None, streaming=False
+    ):
         """
         Runs down-stream inference on samples created from input dictionaries.
         The format of the input `dicts` depends on the task:
 
-        QA:                    [{"qas": ["What is X?"], "context":  "Some context containing the answer"}]
-        Classification / NER / embeddings:  [{"text": "Some input text"}]
+        * QA: [{"qas": ["What is X?"], "context":  "Some context containing the answer"}]
+        * Classification / NER / embeddings: [{"text": "Some input text"}]
+
+
+        Inferencer has a high performance non-blocking streaming mode for large scale inference use cases. With this
+        mode, the dicts parameter can optionally be a Python generator object that yield dicts, thus avoiding loading
+        dicts in memory. The inference_from_dicts() method returns a generator that yield predictions. To use streaming,
+        set the streaming param to True and determine optimal multiprocessing_chunksize by performing speed benchmarks.
 
 
         :param dicts: Samples to run inference on provided as a list of dicts. One dict per sample.
-        :type dicts: [dict]
+        :type dicts: iter(dict)
         :param rest_api_schema: Whether input dicts use the format that complies with the FARM REST API.
                                 Currently only used for QA to switch from squad to a more useful format in production.
                                 While input is almost the same, output contains additional meta data(offset, context..)
         :type rest_api_schema: bool
         :return: dict of predictions
-        :param max_processes: The maximum size of `multiprocessing.Pool`. Set to value of 1 to disable multiprocessing.
-                              If you want to debug the Language Model, you might need to disable multiprocessing!
+        :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
+                              multiprocessing. Set to None to let inferencer determine optimum number. If you want
+                              to debug the Language Model, you might need to disable multiprocessing!
                               For very small number of dicts, time incurred in spawning processes could outweigh
                               performance boost, eg, in the case of HTTP APIs for Inference. For such cases
-                              multiprocessing should be disabled.
-        :param min_chunksize: minimum number of dicts to put together in one chunk and feed to one process
-                              (only relevant if you do multiprocessing)
-        :type min_chunksize: int
+                              multiprocessing should be disabled. This argument is mandatory if used with `streaming`
+                              set to True.
+        :type num_processes: int
+        :param multiprocessing_chunksize: number of dicts to put together in one chunk and feed to one process
+                                          (only relevant if you do multiprocessing)
+        :type multiprocessing_chunksize: int
+        :param streaming: return a Python generator object that yield results as they get computed, instead of blocking
+                          for all the results. To use streaming, the dicts parameter must be a generator and
+                          num_processes argument must be set. This mode can be useful to implement large scale
+                          non-blocking inference pipelines.
+        :type streaming: bool
+
+        :return: an iterator(list or generator) of predictions
+        :rtype: iter
         """
 
         # whether to aggregate predictions across different samples (e.g. for QA on long texts)
@@ -272,48 +311,115 @@ class Inferencer:
         if len(self.model.prediction_heads) > 0:
             aggregate_preds = hasattr(self.model.prediction_heads[0], "aggregate_preds")
 
-        # Using multiprocessing
-        if max_processes > 1:  # use multiprocessing if max_processes > 1
-            multiprocessing_chunk_size, num_cpus_used = calc_chunksize(len(dicts), max_processes=max_processes, min_chunksize=min_chunksize)
+        if num_processes == 0:  # multiprocessing disabled (helpful for debugging or using in web frameworks)
+            predictions = self._inference_without_multiprocessing(dicts, rest_api_schema, aggregate_preds)
+            return predictions
 
-            # Get us some workers (i.e. processes)
-            p = mp.Pool(processes=num_cpus_used)
-            logger.info(
-                f"Got ya {num_cpus_used} parallel workers to do inference on {len(dicts)} dicts (chunksize = {multiprocessing_chunk_size})..."
+        else:  # use multiprocessing for inference
+            # Calculate values of multiprocessing_chunksize and num_processes if not supplied in the parameters.
+            # The calculation of the values is based on whether streaming mode is enabled. This is only for speed
+            # optimization and do not impact the results of inference.
+            if streaming:
+                if not multiprocessing_chunksize:
+                    logger.warning("Streaming mode is enabled for the Inferencer but multiprocessing_chunksize is not "
+                                   "supplied. Continuing with a default value of 20. Perform benchmarking on your data "
+                                   "to get the optimal chunksize.")
+                    multiprocessing_chunksize = 20
+                if not num_processes:  # use all CPU cores if num_processes not set.
+                    num_processes = mp.cpu_count()
+            else:
+                _chunk_size, _num_processes = calc_chunksize(len(dicts))
+                multiprocessing_chunksize = multiprocessing_chunksize or _chunk_size
+                num_processes = num_processes or _num_processes
+
+            predictions = self._inference_with_multiprocessing(
+                dicts, rest_api_schema, aggregate_preds, multiprocessing_chunksize, num_processes,
             )
-            log_ascii_workers(num_cpus_used, logger)
 
-            # We group the input dicts into chunks and feed each chunk to a different process,
-            # where it gets converted to a pytorch dataset
-            results = p.imap(
-                partial(self._create_datasets_chunkwise, processor=self.processor, rest_api_schema=rest_api_schema),
-                grouper(dicts, multiprocessing_chunk_size),
-                1,
-            )
+            # return a generator object if streaming is enabled, else, cast the generator to a list.
+            if not streaming and type(predictions) != list:
+                return list(predictions)
+                return list(itertools.chain(*predictions))
+            else:
+                return predictions
 
-            # Once a process spits out a preprocessed chunk. we feed this dataset directly to the model.
-            # So we don't need to wait until all preprocessing has finished before getting first predictions.
-            preds_all = []
-            with tqdm(total=len(dicts), desc=f"Inferencing Dicts", unit=" Dicts") as pbar:
-                for dataset, tensor_names, baskets in results:
-                    # TODO change format of formatted_preds in QA (list of dicts)
-                    if aggregate_preds:
-                        preds_all.extend(self._get_predictions_and_aggregate(dataset, tensor_names, baskets, rest_api_schema, disable_tqdm=True))
-                    else:
-                        preds_all.extend(self._get_predictions(dataset, tensor_names, baskets, rest_api_schema, disable_tqdm=True))
-                    pbar.update(multiprocessing_chunk_size)
-            p.close()
-            p.join()
-        # Using single process (helpful for debugging!)
+    def _inference_without_multiprocessing(self, dicts, rest_api_schema, aggregate_preds):
+        """
+        Implementation of inference from dicts without using Python multiprocessing. Useful for debugging or in API
+        framework where spawning new processes could be expensive.
+
+        :param dicts: Samples to run inference on provided as a list of dicts. One dict per sample.
+        :type dicts: iter(dict)
+        :param rest_api_schema: Whether input dicts use the format that complies with the FARM REST API.
+                                Currently only used for QA to switch from squad to a more useful format in production.
+                                While input is almost the same, output contains additional meta data(offset, context..)
+        :type rest_api_schema: bool
+        :param aggregate_preds: whether to aggregate predictions across different samples (e.g. for QA on long texts)
+        :type aggregate_preds: bool
+
+        :return: list of predictions
+        :rtype: list
+        """
+        dataset, tensor_names, baskets = self.processor.dataset_from_dicts(
+            dicts, indices=[i for i in range(len(dicts))], rest_api_schema=rest_api_schema, return_baskets=True
+        )
+        # TODO change format of formatted_preds in QA (list of dicts)
+        if aggregate_preds:
+            preds_all = self._get_predictions_and_aggregate(dataset, tensor_names, baskets, rest_api_schema)
         else:
-            chunk = next(grouper(dicts, len(dicts)))
-            dataset, tensor_names, baskets = self._create_datasets_chunkwise(chunk, processor=self.processor, rest_api_schema=rest_api_schema)
+            preds_all = self._get_predictions(dataset, tensor_names, baskets, rest_api_schema)
+        return preds_all
+
+    def _inference_with_multiprocessing(
+        self, dicts, rest_api_schema, aggregate_preds, multiprocessing_chunksize, num_processes
+    ):
+        """
+        Implementation of inference. This method is a generator that yields the results.
+
+        :param dicts: Samples to run inference on provided as a list of dicts or a generator object that yield dicts.
+        :type dicts: iter(dict)
+        :param rest_api_schema: Whether input dicts use the format that complies with the FARM REST API.
+                                Currently only used for QA to switch from squad to a more useful format in production.
+                                While input is almost the same, output contains additional meta data(offset, context..)
+        :type rest_api_schema: bool
+        :param aggregate_preds: whether to aggregate predictions across different samples (e.g. for QA on long texts)
+        :type aggregate_preds: bool
+        :param multiprocessing_chunksize: number of dicts to put together in one chunk and feed to one process
+        :type multiprocessing_chunksize: int
+        :param num_processes: size of multiprocessing.Pool
+        :type num_processes: int
+        :return: generator object that yield predictions
+        :rtype: iter
+        """
+        # Get us some workers (i.e. processes)
+        p = mp.Pool(processes=num_processes)
+        logger.info(
+            f"Got ya {num_processes} parallel workers to do inference on dicts (chunksize = {multiprocessing_chunksize})..."
+        )
+        log_ascii_workers(num_processes, logger)
+
+        # We group the input dicts into chunks and feed each chunk to a different process,
+        # where it gets converted to a pytorch dataset
+        results = p.imap(
+            partial(self._create_datasets_chunkwise, processor=self.processor, rest_api_schema=rest_api_schema),
+            grouper(iterable=dicts, n=multiprocessing_chunksize),
+            1,
+        )
+
+        # Once a process spits out a preprocessed chunk. we feed this dataset directly to the model.
+        # So we don't need to wait until all preprocessing has finished before getting first predictions.
+        for dataset, tensor_names, baskets in results:
             # TODO change format of formatted_preds in QA (list of dicts)
             if aggregate_preds:
-                preds_all = self._get_predictions_and_aggregate(dataset, tensor_names, baskets, rest_api_schema)
+                predictions = self._get_predictions_and_aggregate(
+                    dataset, tensor_names, baskets, rest_api_schema, disable_tqdm=True
+                )
             else:
-                preds_all = self._get_predictions(dataset, tensor_names, baskets, rest_api_schema)
-        return preds_all
+                predictions = self._get_predictions(dataset, tensor_names, baskets, rest_api_schema, disable_tqdm=True)
+            yield from predictions
+
+        p.close()
+        p.join()
 
     @classmethod
     def _create_datasets_chunkwise(cls, chunk, processor, rest_api_schema):

--- a/farm/inference_rest_api.py
+++ b/farm/inference_rest_api.py
@@ -83,7 +83,7 @@ class InferenceEndpoint(Resource):
         dicts = request.get_json().get("input", None)
         if not dicts:
             return {}
-        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True, max_processes=1)
+        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True, num_processes=0)
         return results[0]
 
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -1,9 +1,11 @@
 import pytest
 
 
-@pytest.mark.parametrize("max_processes", [2, 1])
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.parametrize("multiprocessing_chunksize", [None, 0, 2])
+@pytest.mark.parametrize("num_processes", [None, 0, 2])
 @pytest.mark.parametrize("rest_api_schema", [True, False])
-def test_qa_format_and_results(adaptive_model_qa, max_processes, rest_api_schema):
+def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, num_processes, rest_api_schema):
 
     qa_inputs_dicts = [
         {
@@ -25,7 +27,9 @@ def test_qa_format_and_results(adaptive_model_qa, max_processes, rest_api_schema
 
     results = adaptive_model_qa.inference_from_dicts(
         dicts=qa_inputs_dicts,
-        max_processes=max_processes,
+        num_processes=num_processes,
+        multiprocessing_chunksize=multiprocessing_chunksize,
+        streaming=streaming,
         rest_api_schema=True,
     )
     # sample results
@@ -54,7 +58,7 @@ def test_qa_format_and_results(adaptive_model_qa, max_processes, rest_api_schema
     #         ],
     #     }
     # ]
-    predictions = results[0]["predictions"]
+    predictions = list(results)[0]["predictions"]
 
     for prediction, ground_truth, qa_input_dict in zip(
         predictions, ground_truths, qa_inputs_dicts

--- a/test/test_ner.py
+++ b/test/test_ner.py
@@ -86,7 +86,7 @@ def test_ner(caplog):
         {"text": "Albrecht Lehman ist eine Person"},
     ]
     model = Inferencer.load(save_dir)
-    result = model.inference_from_dicts(dicts=basic_texts, max_processes=1)
+    result = model.inference_from_dicts(dicts=basic_texts)
     #print(result)
     #assert result[0]["predictions"][0]["context"] == "sagte"
     #assert isinstance(result[0]["predictions"][0]["probability"], np.float32)

--- a/test/test_ner_amp.py
+++ b/test/test_ner_amp.py
@@ -89,8 +89,8 @@ def test_ner_amp(caplog):
         {"text": "1980 kam der Crown von Toyota"},
     ]
     model = Inferencer.load(save_dir, gpu=True)
-    result = model.inference_from_dicts(dicts=basic_texts, max_processes=1)
-    #print(result)
+    result = model.inference_from_dicts(dicts=basic_texts)
+
     assert result[0]["predictions"][0]["context"] == "Crown"
     assert isinstance(result[0]["predictions"][0]["probability"], np.float32)
 


### PR DESCRIPTION
This PR adds a high-performance non-blocking streaming mode for large scale inference use cases. With this mode, the `dicts` parameter in `Inferencer.inference_from_dicts()` can optionally be a Python generator object that yields dicts, thus avoiding loading all dicts in memory. The `inference_from_dicts()` method would return a generator that yield inference predictions.