### PR TITLE
Fix Issues with NER format Conversion

### DIFF
--- a/examples/ner.py
+++ b/examples/ner.py
@@ -31,7 +31,7 @@ def ner():
     n_epochs = 4
     batch_size = 32
     evaluate_every = 400
-    lang_model =  "bert-base-german-cased"
+    lang_model = "bert-base-german-cased"
     do_lower_case = False
 
     # 1.Create a tokenizer
@@ -40,6 +40,7 @@ def ner():
     )
 
     # 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
+    # See test/sample/ner/train-sample.txt for an example of the data format that is expected by the Processor
     ner_labels = ["[PAD]", "X", "O", "B-MISC", "I-MISC", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "B-OTH", "I-OTH"]
 
     processor = NERProcessor(

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -133,7 +133,7 @@ def read_ner_file(filename, sep="\t", proxies=None):
             continue
         if len(line) == 0 or "-DOCSTART-" in line or line[0] == "\n":
             if len(sentence) > 0:
-                if "conll03-de" in str(filename):
+                if "conll03" in str(filename):
                     _convertIOB1_to_IOB2(label)
                 if "germeval14" in str(filename):
                     label = _convert_germeval14_labels(label)

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -188,6 +188,7 @@ def to_numpy(container):
 
 
 def convert_iob_to_simple_tags(preds, spans):
+    contains_named_entity = len([x for x in preds if x != "O"]) != 0
     simple_tags = []
     merged_spans = []
     open_tag = False
@@ -224,6 +225,10 @@ def convert_iob_to_simple_tags(preds, spans):
         merged_spans.append(cur_span)
         simple_tags.append(cur_tag)
         open_tag = False
+    if contains_named_entity and len(simple_tags) == 0:
+        raise Exception("Predicted Named Entities lost when converting from IOB to simple tags. Please check the format"
+                        "of the training data adheres to either adheres to IOB2 format or is converted when "
+                        "read_ner_file() is called.")
     return simple_tags, merged_spans
 
 


### PR DESCRIPTION
- Fixes an issue where conll-en was not being converted to IOB2
- Adds a comment in the example that points users to an NER data example
- Code will raise an exception if a predicted named entity is lost during conversion from IOB to simple tags

This should address #320 and help with #287