### PR TITLE
Fix the IOB2 to simple tags check

### DIFF
--- a/farm/utils.py
+++ b/farm/utils.py
@@ -188,7 +188,7 @@ def to_numpy(container):
 
 
 def convert_iob_to_simple_tags(preds, spans):
-    contains_named_entity = len([x for x in preds if x != "O"]) != 0
+    contains_named_entity = len([x for x in preds if "B-" in x]) != 0
     simple_tags = []
     merged_spans = []
     open_tag = False


### PR DESCRIPTION
Provides a more accurate check for the IOB2 to simple tags conversion. Now, the Exception is only triggered when there is a "B-" entity in the predictions and no simple tag is generated. This will fix a failing NER test as well.