### PR TITLE
Group NER preds by sample

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -686,7 +686,7 @@ class TokenClassificationHead(PredictionHead):
                         "probability": prob,
                     }
                 )
-            res["predictions"].extend(seq_res)
+            res["predictions"].append(seq_res)
         return res
 
 

--- a/test/test_ner_amp.py
+++ b/test/test_ner_amp.py
@@ -91,7 +91,7 @@ def test_ner_amp(caplog):
     model = Inferencer.load(save_dir, gpu=True)
     result = model.inference_from_dicts(dicts=basic_texts)
 
-    assert result[0]["predictions"][0]["context"] == "Crown"
+    assert result[0]["predictions"][0][0]["context"] == "Crown"
     assert isinstance(result[0]["predictions"][0]["probability"], np.float32)
 
 

--- a/test/test_ner_amp.py
+++ b/test/test_ner_amp.py
@@ -92,7 +92,7 @@ def test_ner_amp(caplog):
     result = model.inference_from_dicts(dicts=basic_texts)
 
     assert result[0]["predictions"][0][0]["context"] == "Crown"
-    assert isinstance(result[0]["predictions"][0]["probability"], np.float32)
+    assert isinstance(result[0]["predictions"][0][0]["probability"], np.float32)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, when the inferencer was fed more than one sample, all predictions were returned in one list. Now it returns one list for each sample filled with that sample's predictions. Addresses #326