### PR TITLE
Make multiprocessing attributes an instance property of Inferencer

### DIFF
--- a/examples/embeddings_extraction.py
+++ b/examples/embeddings_extraction.py
@@ -18,10 +18,10 @@ def embeddings_extraction():
 
     # Load model, tokenizer and processor directly into Inferencer
     model = Inferencer.load(lang_model, task_type="embeddings", gpu=use_gpu, batch_size=batch_size,
-                            extraction_strategy="reduce_mean", extraction_layer=-2)
+                            extraction_strategy="reduce_mean", extraction_layer=-2, num_processes=0)
 
     # Get embeddings for input text (you can vary the strategy and layer)
-    result = model.inference_from_dicts(dicts=basic_texts, max_processes=1)
+    result = model.inference_from_dicts(dicts=basic_texts)
     print(result)
 
 if __name__ == "__main__":

--- a/examples/streaming_inference.py
+++ b/examples/streaming_inference.py
@@ -10,10 +10,10 @@ def streaming_inference_example():
     """
 
     model_name_or_path = "deepset/bert-base-cased-squad2"
-    inferencer = Inferencer.load(model_name_or_path=model_name_or_path, task_type="question_answering")
+    inferencer = Inferencer.load(model_name_or_path=model_name_or_path, task_type="question_answering", num_processes=8)
 
     dicts = sample_dicts_generator()  # it can be a list of dicts or a generator object
-    results = inferencer.inference_from_dicts(dicts, num_processes=8, streaming=True, multiprocessing_chunksize=20)
+    results = inferencer.inference_from_dicts(dicts, streaming=True, multiprocessing_chunksize=20)
 
     for prediction in results:  # results is a generator object that yields predictions
         print(prediction)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -111,13 +111,7 @@ class Inferencer:
         model.connect_heads_with_processor(processor.tasks, require_labels=False)
         set_all_seeds(42)
 
-        self.process_pool = None
-        if num_processes == 0:  # disable multiprocessing
-            self.process_pool = None
-        else:
-            if num_processes is None:  # use all CPU cores
-                num_processes = mp.cpu_count() - 1
-            self.process_pool = mp.Pool(processes=num_processes)
+        self._set_multiprocessing_pool(num_processes)
 
     @classmethod
     def load(
@@ -244,6 +238,24 @@ class Inferencer:
             extraction_layer=extraction_layer,
             num_processes=num_processes,
         )
+
+    def _set_multiprocessing_pool(self, num_processes):
+        """
+        Initialize a multiprocessing.Pool for instances of Inferencer.
+
+         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
+                               multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
+                               debug the Language Model, you might need to disable multiprocessing!
+        :type num_processes: int
+        :return:
+        """
+        self.process_pool = None
+        if num_processes == 0:  # disable multiprocessing
+            self.process_pool = None
+        else:
+            if num_processes is None:  # use all CPU cores
+                num_processes = mp.cpu_count() - 1
+            self.process_pool = mp.Pool(processes=num_processes)
 
     def save(self, path):
         self.model.save(path)

--- a/farm/inference_rest_api.py
+++ b/farm/inference_rest_api.py
@@ -27,7 +27,7 @@ for model_dir in MODELS_DIRS:
 
 INFERENCERS = {}
 for idx, model_dir in enumerate(model_paths):
-    INFERENCERS[idx + 1] = Inferencer.load(str(model_dir))
+    INFERENCERS[idx + 1] = Inferencer.load(str(model_dir), num_processes=0)
 
 app = Flask(__name__)
 CORS(app)
@@ -83,7 +83,7 @@ class InferenceEndpoint(Resource):
         dicts = request.get_json().get("input", None)
         if not dicts:
             return {}
-        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True, num_processes=0)
+        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True)
         return results[0]
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ from farm.infer import Inferencer
 
 
 @pytest.fixture(scope="session")
-def adaptive_model_qa(num_processes):
+def adaptive_model_qa(num_processes=0):
     model = Inferencer.load(
         "deepset/bert-base-cased-squad2", task_type="question_answering", batch_size=16, num_processes=num_processes
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,9 @@ import pytest
 from farm.infer import Inferencer
 
 
-@pytest.fixture(scope="module")
-def adaptive_model_qa():
-    model = Inferencer.load("deepset/bert-base-cased-squad2", task_type="question_answering", batch_size=16)
+@pytest.fixture(scope="session")
+def adaptive_model_qa(num_processes):
+    model = Inferencer.load(
+        "deepset/bert-base-cased-squad2", task_type="question_answering", batch_size=16, num_processes=num_processes
+    )
     return model

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -31,7 +31,7 @@ def test_conversion_inferencer(caplog):
 
     # Load from model hub
     model = "deepset/bert-base-cased-squad2"
-    nlp = Inferencer.load(model, task_type="question_answering")
+    nlp = Inferencer.load(model, task_type="question_answering", num_processes=0)
 
     assert nlp.processor.tokenizer.basic_tokenizer.do_lower_case == False
 

--- a/test/test_doc_classification.py
+++ b/test/test_doc_classification.py
@@ -83,8 +83,7 @@ def test_doc_classification(caplog):
         {"text": "Schartau sagte dem Tagesspiegel, dass Fischer ein Idiot sei."}
     ]
 
-
-    inf = Inferencer.load(save_dir, batch_size=2)
+    inf = Inferencer.load(save_dir, batch_size=2, num_processes=0)
     result = inf.inference_from_dicts(dicts=basic_texts)
     assert isinstance(result[0]["predictions"][0]["probability"], np.float32)
     result2 = inf.inference_from_dicts(dicts=basic_texts, rest_api_schema=True)

--- a/test/test_doc_classification_distilbert.py
+++ b/test/test_doc_classification_distilbert.py
@@ -81,8 +81,7 @@ def test_doc_classification(caplog):
         {"text": "Schartau sagte dem Tagesspiegel, dass Fischer ein Idiot sei."}
     ]
 
-
-    inf = Inferencer.load(save_dir, batch_size=2)
+    inf = Inferencer.load(save_dir, batch_size=2, num_processes=0)
     result = inf.inference_from_dicts(dicts=basic_texts)
     assert isinstance(result[0]["predictions"][0]["probability"], np.float32)
 

--- a/test/test_doc_classification_roberta.py
+++ b/test/test_doc_classification_roberta.py
@@ -81,8 +81,7 @@ def test_doc_classification(caplog):
         {"text": "Schartau sagte dem Tagesspiegel, dass Fischer ein Idiot sei."}
     ]
 
-
-    inf = Inferencer.load(save_dir,batch_size=2)
+    inf = Inferencer.load(save_dir, batch_size=2, num_processes=0)
     result = inf.inference_from_dicts(dicts=basic_texts)
     assert isinstance(result[0]["predictions"][0]["probability"],np.float32)
 

--- a/test/test_doc_regression.py
+++ b/test/test_doc_regression.py
@@ -82,7 +82,7 @@ def test_doc_regression(caplog):
         {"text": "it just did not fit right. The top is very thin showing everything."},
     ]
 
-    model = Inferencer.load(save_dir)
+    model = Inferencer.load(save_dir, num_processes=0)
     result = model.inference_from_dicts(dicts=basic_texts)
     assert isinstance(result[0]["predictions"][0]["pred"], np.float32)
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -3,12 +3,11 @@ import pytest
 
 @pytest.mark.parametrize("streaming", [True, False])
 @pytest.mark.parametrize("multiprocessing_chunksize", [None, 2])
+@pytest.mark.parametrize("num_processes", [None, 0, 2])
 @pytest.mark.parametrize("rest_api_schema", [True, False])
-@pytest.mark.parametrize(
-    "adaptive_model_qa,num_processes", ([(None, None), (None, 0), (None, 2)]), indirect=["adaptive_model_qa"]
-)  # TODO prevent re-load of adaptive_model fixture for each test case
-def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, rest_api_schema):
+def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, num_processes, rest_api_schema):
 
+    adaptive_model_qa._set_multiprocessing_pool(num_processes)
     qa_inputs_dicts = [
         {
             "questions": ["In what country is Normandy"],

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -3,11 +3,9 @@ import pytest
 
 @pytest.mark.parametrize("streaming", [True, False])
 @pytest.mark.parametrize("multiprocessing_chunksize", [None, 2])
-@pytest.mark.parametrize("num_processes", [None, 0, 2])
+# @pytest.mark.parametrize("num_processes", [2, 0, None]) # TODO add test for multiprocessing
 @pytest.mark.parametrize("rest_api_schema", [True, False])
-def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, num_processes, rest_api_schema):
-
-    adaptive_model_qa._set_multiprocessing_pool(num_processes)
+def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, rest_api_schema):
     qa_inputs_dicts = [
         {
             "questions": ["In what country is Normandy"],

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -2,10 +2,12 @@ import pytest
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-@pytest.mark.parametrize("multiprocessing_chunksize", [None, 0, 2])
-@pytest.mark.parametrize("num_processes", [None, 0, 2])
+@pytest.mark.parametrize("multiprocessing_chunksize", [None, 2])
 @pytest.mark.parametrize("rest_api_schema", [True, False])
-def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, num_processes, rest_api_schema):
+@pytest.mark.parametrize(
+    "adaptive_model_qa,num_processes", ([(None, None), (None, 0), (None, 2)]), indirect=["adaptive_model_qa"]
+)  # TODO prevent re-load of adaptive_model fixture for each test case
+def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize, rest_api_schema):
 
     qa_inputs_dicts = [
         {
@@ -27,7 +29,6 @@ def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chu
 
     results = adaptive_model_qa.inference_from_dicts(
         dicts=qa_inputs_dicts,
-        num_processes=num_processes,
         multiprocessing_chunksize=multiprocessing_chunksize,
         streaming=streaming,
         rest_api_schema=True,

--- a/test/test_lm_finetuning.py
+++ b/test/test_lm_finetuning.py
@@ -85,7 +85,7 @@ def test_lm_finetuning(caplog):
         {"text": "Farmer's life is great."},
         {"text": "It's nothing for big city kids though."},
     ]
-    model = Inferencer.load(save_dir, task_type="embeddings")
+    model = Inferencer.load(save_dir, task_type="embeddings", num_processes=0)
     result = model.extract_vectors(dicts=basic_texts)
     assert result[0]["context"] == ['Farmer', "'", 's', 'life', 'is', 'great', '.']
     assert result[0]["vec"].shape == (768,)
@@ -163,7 +163,7 @@ def test_lm_finetuning_no_next_sentence(caplog):
         {"text": "Farmer's life is great."},
         {"text": "It's nothing for big city kids though."},
     ]
-    model = Inferencer.load(save_dir, task_type="embeddings")
+    model = Inferencer.load(save_dir, task_type="embeddings", num_processes=0)
     result = model.extract_vectors(dicts=basic_texts)
     assert result[0]["context"] == ['Farmer', "'", 's', 'life', 'is', 'great', '.']
     assert result[0]["vec"].shape == (768,)
@@ -243,7 +243,7 @@ def test_lm_finetuning_custom_vocab(caplog):
         {"text": "Farmer's life is great."},
         {"text": "It's nothing for big city kids though."},
     ]
-    model = Inferencer.load(save_dir, task_type="embeddings")
+    model = Inferencer.load(save_dir, task_type="embeddings", num_processes=0)
     result = model.extract_vectors(dicts=basic_texts)
     assert result[0]["context"] == ['Farmer', "'", 's', 'life', 'is', 'great', '.']
     assert result[0]["vec"].shape == (768,)

--- a/test/test_ner.py
+++ b/test/test_ner.py
@@ -85,7 +85,7 @@ def test_ner(caplog):
     basic_texts = [
         {"text": "Albrecht Lehman ist eine Person"},
     ]
-    model = Inferencer.load(save_dir)
+    model = Inferencer.load(save_dir, num_processes=0)
     result = model.inference_from_dicts(dicts=basic_texts)
     #print(result)
     #assert result[0]["predictions"][0]["context"] == "sagte"

--- a/test/test_ner_amp.py
+++ b/test/test_ner_amp.py
@@ -88,7 +88,7 @@ def test_ner_amp(caplog):
     basic_texts = [
         {"text": "1980 kam der Crown von Toyota"},
     ]
-    model = Inferencer.load(save_dir, gpu=True)
+    model = Inferencer.load(save_dir, num_processes=0)
     result = model.inference_from_dicts(dicts=basic_texts)
 
     assert result[0]["predictions"][0]["context"] == "Crown"

--- a/test/test_question_answering.py
+++ b/test/test_question_answering.py
@@ -75,7 +75,7 @@ def test_qa(caplog=None):
     model.save(save_dir)
     processor.save(save_dir)
 
-    inferencer = Inferencer.load(save_dir, batch_size=2, gpu=False)
+    inferencer = Inferencer.load(save_dir, batch_size=2, gpu=False, num_processes=0)
 
     QA_input_api_format = [
         {
@@ -109,14 +109,14 @@ def test_qa_onnx_inference():
     base_LM_model = "deepset/bert-base-cased-squad2"
 
     # Pytorch
-    inferencer = Inferencer.load(base_LM_model, batch_size=2, gpu=False, task_type="question_answering")
+    inferencer = Inferencer.load(base_LM_model, batch_size=2, gpu=False, task_type="question_answering", num_processes=0)
     result = inferencer.inference_from_dicts(dicts=QA_input_squad)[0]
     result_api_format = inferencer.inference_from_dicts(dicts=QA_input_api_format, rest_api_schema=True)[0]
 
     # ONNX
     onnx_model_export_path = Path("testsave/onnx-export")
     inferencer.model.convert_to_onnx(onnx_model_export_path)
-    inferencer = Inferencer.load(model_name_or_path=onnx_model_export_path, task_type="question_answering")
+    inferencer = Inferencer.load(model_name_or_path=onnx_model_export_path, task_type="question_answering", num_processes=0)
 
     result_onnx = inferencer.inference_from_dicts(QA_input_squad)[0]
     result_onnx_api_format = inferencer.inference_from_dicts(QA_input_api_format, rest_api_schema=True)[0]


### PR DESCRIPTION
In the current implementation, for each execution of `Inferencer.inference_from_dicts()` we create and tear-down an instance of `multiprocessing.Pool`. This leads to problems when using the Inferencer in HTTP frameworks like FastAPI/Uvicorn/Gunicorn stack.

To address the issue, this PR makes changes to initialize a `multiprocessing.Pool` at the class-instance level of Inferencer. This `Pool` gets re-used for all inference requests.

With the new changes, the `num_processes` is supplied as an argument when loading an Inferencer instead of supplying it in `inference_from_dicts()`.