### PR TITLE
Registration and parametrization for evaluation reports

### DIFF
--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -3,15 +3,28 @@ import numpy as np
 import pandas as pd
 from scipy.stats import pearsonr, spearmanr
 from seqeval.metrics import f1_score as ner_f1_score
-from sklearn.metrics import matthews_corrcoef, recall_score, precision_score, f1_score, mean_squared_error, r2_score
+from seqeval.metrics import classification_report as token_classification_report
+from sklearn.metrics import (
+    matthews_corrcoef,
+    recall_score,
+    precision_score,
+    f1_score,
+    mean_squared_error,
+    r2_score,
+    classification_report
+)
 from farm.utils import flatten_list
 import logging
 
 logger = logging.getLogger(__name__)
 
 registered_metrics = {}
+registered_ph_output_types = {}
 
 def register_metrics(name, implementation):
+    registered_metrics[name] = implementation
+
+def register_ph_output_type(name, implementation):
     registered_metrics[name] = implementation
 
 def simple_accuracy(preds, labels):
@@ -71,6 +84,42 @@ def compute_metrics(metric, preds, labels):
         return metric_func(preds, labels)
     else:
         raise KeyError(metric)
+
+
+def compute_report_metrics(head, preds, labels):
+    if head.ph_output_type == "per_token":
+        report_fn = token_classification_report
+    elif head.ph_output_type == "per_sequence":
+        report_fn = classification_report
+    elif head.ph_output_type == "per_token_squad":
+        report_fn = lambda *args, **kwargs: "Not Implemented"
+    elif head.ph_output_type == "per_sequence_continuous":
+        report_fn = r2_score
+    elif head.ph_output_type in registered_ph_output_types:
+        report_fn = register_ph_output_type[head.ph_output_type]
+    else:
+        raise AttributeError(head.ph_output_type)
+
+    # CHANGE PARAMETERS, not all report_fn accept digits
+    if head.ph_output_type in ["per_sequence"]:
+        # supply labels as all possible combination because if ground truth labels do not cover
+        # all values in label_list (maybe dev set is small), the report will break
+        if head.model_type == "multilabel_text_classification":
+            # For multilabel classification, we don't eval with string labels here, but with multihot vectors.
+            # Therefore we need to supply all possible label ids instead of label values.
+            all_possible_labels = list(range(len(head.label_list)))
+        else:
+            all_possible_labels = head.label_list
+        return report_fn(
+            labels,
+            preds,
+            digits=4,
+            labels=all_possible_labels,
+            target_names=head.label_list
+        )
+    else:
+        return report_fn(labels, preds)
+
 
 def squad_EM(preds, labels):
     # TODO write comment describing function

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -25,7 +25,7 @@ def register_metrics(name, implementation):
     registered_metrics[name] = implementation
 
 def register_ph_output_type(name, implementation):
-    registered_metrics[name] = implementation
+    registered_ph_output_types[name] = implementation
 
 def simple_accuracy(preds, labels):
     # works also with nested lists of different lengths (needed for masked LM task)

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -103,7 +103,7 @@ def compute_metrics(metric, preds, labels):
 
 def compute_report_metrics(head, preds, labels):
     if head.ph_output_type in registered_reports:
-        report_fn = register_report[head.ph_output_type]
+        report_fn = registered_reports[head.ph_output_type]
     elif head.ph_output_type == "per_token":
         report_fn = token_classification_report
     elif head.ph_output_type == "per_sequence":

--- a/farm/train.py
+++ b/farm/train.py
@@ -112,6 +112,7 @@ class Trainer:
         device,
         lr_schedule=None,
         evaluate_every=100,
+        eval_report=True,
         use_amp=None,
         grad_acc_steps=1,
         local_rank=-1,
@@ -137,6 +138,8 @@ class Trainer:
         :param lr_schedule: An optional scheduler object that can regulate the learning rate of the optimizer
         :param evaluate_every: Perform dev set evaluation after this many steps of training.
         :type evaluate_every: int
+        :param eval_report: If evaluate_every is not 0, specifies if an eval report should be generated when evaluating
+        :type eval_report: bool
         :param use_amp: Whether to use automatic mixed precision with Apex. One of the optimization levels must be chosen.
                         "O1" is recommended in almost all cases.
         :type use_amp: str
@@ -174,6 +177,7 @@ class Trainer:
         self.epochs = int(epochs)
         self.optimizer = optimizer
         self.evaluate_every = evaluate_every
+        self.eval_report = eval_report
         self.n_gpu = n_gpu
         self.grad_acc_steps = grad_acc_steps
         self.use_amp = use_amp
@@ -253,7 +257,7 @@ class Trainer:
                     dev_data_loader = self.data_silo.get_data_loader("dev")
                     if dev_data_loader is not None:
                         evaluator_dev = Evaluator(
-                            data_loader=dev_data_loader, tasks=self.data_silo.processor.tasks, device=self.device
+                            data_loader=dev_data_loader, tasks=self.data_silo.processor.tasks, device=self.device, report=self.eval_report
                         )
                         evalnr += 1
                         result = evaluator_dev.eval(self.model)


### PR DESCRIPTION
Related to issue #325 that was deemed as interesting by maintainers:
- Moved code to compute report metrics inside `metrics.py`, refactoring it into the ad-hoc function `compute_report_metrics`.
- Added the function `register_ph_output_type` inside `metrics.py` to allow for custom metric registration in the context of evaluation reports.
- Added `eval_report` parameter in the `Trainer` class to allow switching off reporting when `evaluate_every` param is > 0.