### PR TITLE
tqdm progress bar in inferencer

### DIFF
--- a/farm/infer.py
+++ b/farm/infer.py
@@ -14,7 +14,7 @@ from farm.data_handler.utils import grouper
 from farm.modeling.tokenization import Tokenizer
 from farm.modeling.adaptive_model import AdaptiveModel, BaseAdaptiveModel
 from farm.utils import initialize_device_settings
-from farm.utils import set_all_seeds, calc_chunksize
+from farm.utils import set_all_seeds, calc_chunksize, log_ascii_workers
 
 
 logger = logging.getLogger(__name__)
@@ -276,6 +276,10 @@ class Inferencer:
             if num_processes is None:  # use all CPU cores
                 num_processes = mp.cpu_count() - 1
             self.process_pool = mp.Pool(processes=num_processes)
+            logger.info(
+                f"Got ya {num_processes} parallel workers to do inference ..."
+            )
+            log_ascii_workers(n=num_processes,logger=logger)
 
     def save(self, path):
         self.model.save(path)

--- a/farm/modeling/wordembedding_utils.py
+++ b/farm/modeling/wordembedding_utils.py
@@ -45,10 +45,6 @@ class Fasttext_converter():
     Class to use fasttext inside FARM by converting embeddings to format usable by preprocessing pipeline.
     Farm needs fixed vocab and embeddings. We can construct a vocab for the data we wish to embed.
     """
-    try:
-        import fasttext  # fasttext import is optional in requirements. So we just load it when needed.
-    except ModuleNotFoundError:
-        logger.error("Could not find fasttext. Please install through 'pip install fasttext==0.9.1'.")
 
     def __init__(self,
                  pretrained_model_name_or_path,
@@ -77,6 +73,10 @@ class Fasttext_converter():
         :param min_vocab_count: when constructing the vocab, words with less than min_vocab_count occurrences are ignored
         :param max_features: maximum number of words to use in vocab
         """
+        try:
+            import fasttext  # fasttext import is optional in requirements. So we just load it when needed.
+        except ModuleNotFoundError:
+            logger.error("Could not find fasttext. Please install through 'pip install fasttext==0.9.1'.")
 
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
         self.do_lower_case = do_lower_case


### PR DESCRIPTION
So far: we disabled tqdm for all inference with mulitprocessing as it can become quite verbose. 

Proposed change: Make `disable_tqdm` a class attribute so that users can configure it more flexible themself. 

(In addition, I moved the fasttext import as we were always logging an error message even though it was not used at all ) 