### PR TITLE
Add english glove models

### DIFF
--- a/examples/embeddings_extraction_s3e_pooling.py
+++ b/examples/embeddings_extraction_s3e_pooling.py
@@ -97,8 +97,7 @@ def extract_embeddings(load_dir, use_gpu, batch_size):
 
 
 if __name__ == "__main__":
-    #TODO update to an english public model
-    lang_model = "glove-german-uncased"
+    lang_model = "glove-english-uncased-6B"
 
     # You can download this from:
     # "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/lm_finetune_nips.tar.gz"

--- a/examples/embeddings_extraction_s3e_pooling.py
+++ b/examples/embeddings_extraction_s3e_pooling.py
@@ -98,7 +98,8 @@ def extract_embeddings(load_dir, use_gpu, batch_size):
 
 if __name__ == "__main__":
     lang_model = "glove-english-uncased-6B"
-
+    do_lower_case = True
+    
     # You can download this from:
     # "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/lm_finetune_nips.tar.gz"
     corpus_path = Path("../data/lm_finetune_nips/train.txt")
@@ -106,7 +107,7 @@ if __name__ == "__main__":
     s3e_dir = Path("../saved_models/fitted_s3e/")
 
     fit(language_model=lang_model,
-        do_lower_case=False,
+        do_lower_case=do_lower_case,
         corpus_path=corpus_path,
         save_dir=s3e_dir
         )

--- a/farm/modeling/wordembedding_utils.py
+++ b/farm/modeling/wordembedding_utils.py
@@ -23,8 +23,8 @@ from farm.file_utils import load_from_cache
 # language model config
 PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "glove-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-german-uncased/language_model_config.json",
-    "glove-english-uncased-6B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-uncased-6B/language_model_config.txt",
-    "glove-english-cased-840B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-cased-840B/language_model_config.txt",
+    "glove-english-uncased-6B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-uncased-6B/language_model_config.json",
+    "glove-english-cased-840B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-cased-840B/language_model_config.json",
 }
 # tokenization
 EMBEDDING_VOCAB_FILES_MAP = {}

--- a/farm/modeling/wordembedding_utils.py
+++ b/farm/modeling/wordembedding_utils.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import unicodedata
-from pathlib import Path, PurePath
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -22,16 +22,30 @@ from farm.file_utils import load_from_cache
 # the dicts need to be used with HF transformers to use their data + modelling functionality
 # language model config
 PRETRAINED_CONFIG_ARCHIVE_MAP = {
-    "glove-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-german-uncased/language_model_config.json"}
+    "glove-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-german-uncased/language_model_config.json",
+    "glove-english-uncased-6B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-uncased-6B/language_model_config.txt",
+    "glove-english-cased-840B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-cased-840B/language_model_config.txt",
+}
 # tokenization
 EMBEDDING_VOCAB_FILES_MAP = {}
 EMBEDDING_VOCAB_FILES_MAP["vocab_file"] = {
-    "glove-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-german-uncased/vocab.txt"}
-MAX_MODEL_INPU_SIZES = {"glove-german-uncased": 10000}
-PRETRAINED_INIT_CONFIGURATION = {"glove-german-uncased": {"do_lower_case": False}}
+    "glove-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-german-uncased/vocab.txt",
+    "glove-english-uncased-6B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-uncased-6B/vocab.txt",
+    "glove-english-cased-840B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-cased-840B/vocab.txt",
+}
+MAX_MODEL_INPU_SIZES = {
+    "glove-german-uncased": 10000,
+    "glove-english-uncased-6B": 10000,
+    "glove-english-cased-840B": 10000,
+}
+PRETRAINED_INIT_CONFIGURATION = {"glove-german-uncased": {"do_lower_case": True},
+                                 "glove-english-uncased-6B": {"do_lower_case": True},
+                                 "glove-english-cased-840B": {"do_lower_case": False}}
 # model
 EMBEDDING_MODEL_MAP = {
     "glove-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-german-uncased/vectors.txt",
+    "glove-english-uncased-6B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-uncased-6B/vectors.txt",
+    "glove-english-cased-840B": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/glove-english-cased-840B/vectors.txt",
     "fasttext-german-uncased": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-models/0.4.1/fasttext-german-uncased/language_model.bin",
 }
 # conversion


### PR DESCRIPTION
Add two english glove models: 
- `glove-english-uncased-6B`: Wikipedia 2014 + Gigaword 5 (6B tokens, 400K vocab, uncased, 300d vectors)
- `glove-english-cased-840B`: Common Crawl (840B tokens, 2.2M vocab, cased, 300d vectors)

From: https://nlp.stanford.edu/projects/glove/