### PR TITLE
Make ONNXRuntime dependency optional

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,7 @@ jobs:
       displayName: 'Install dependencies'
 
     - script: |
-        pip install pytest pytest-azurepipelines
-        cd test && pytest
+        cd test && pip install -r requirements.txt && pytest
       displayName: 'pytest'
 
     - script: |

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import multiprocessing
 import numpy
-import onnxruntime
 import torch
 from torch import nn
 from transformers.modeling_auto import AutoModelForQuestionAnswering, AutoModelForSequenceClassification, AutoModelForTokenClassification, AutoModelWithLMHead
@@ -737,6 +736,7 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
 
     @classmethod
     def load(cls, load_dir, device, **kwargs):
+        import onnxruntime
         sess_options = onnxruntime.SessionOptions()
         # Set graph optimization level to ORT_ENABLE_EXTENDED to enable bert optimization.
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ flask
 flask-restplus
 flask-cors
 dill # pickle extension for (de-)serialization
+# optional for inference
+#fasttext==0.9.1
+#onnxruntime  # Inference with ONNX models. Install onnxruntime-gpu for Inference on GPUs

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,4 @@ Werkzeug==0.16.1
 flask
 flask-restplus
 flask-cors
-# optional: for inference with fasttext
-#fasttext==0.9.1
 dill # pickle extension for (de-)serialization
-onnxruntime  # Inference with ONNX models. Install onnxruntime-gpu for Inference on GPUs

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=parsed_requirements,
     python_requires=">=3.5.0",
+    extras_require={
+        "fasttext": ["fasttext==0.9.1"],
+        "onnx": ["onnxruntime"],
+    },
     tests_require=["pytest"],
     classifiers=[
         "Intended Audience :: Science/Research",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-azurepipelines
+pytest-benchmark
+onnxruntime

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-azurepipelines
-pytest-benchmark
 onnxruntime


### PR DESCRIPTION
This PR fixes #344 by making ONNXRuntime dependency optional. 

To install from source, run `pip install -e .[onnx]` or `pip install farm[onnx]` to install from PyPI.