### PR TITLE
allows data_silo.calculate_class_weights to support multilabel

### DIFF
--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -477,7 +477,8 @@ class DataSilo:
             raise Exception("source argument expects one of [\"train\", \"all\"]")
         for dataset in datasets:
             if dataset is not None:
-                observed_labels += [label_list[x[tensor_idx].item()] for x in dataset]
+                for x in dataset:
+                    observed_labels += [label_list[label_id] for label_id in (x[tensor_idx] == 1).nonzero()]
         #TODO scale e.g. via logarithm to avoid crazy spikes for rare classes
         class_weights = list(compute_class_weight("balanced", np.asarray(label_list), observed_labels))
         return class_weights


### PR DESCRIPTION
I was having an issue with using `TextClassificationProcessor(multilabel=True)` together with `data_silo.calculate_class_weights`

I belive this commit solves the issue, please let me know if it's the way to go.

    processor = TextClassificationProcessor(
                                            multilabel=True,
                                            )

    data_silo = DataSilo(
        processor=processor,
        batch_size=batch_size)

    language_model = LanguageModel.load(lang_model)
    prediction_head = MultiLabelTextClassificationHead(
        class_weights=data_silo.calculate_class_weights(task_name="text_classification"),
        num_labels=len(label_list))