### PR TITLE
Make onnx imports optional

### DIFF
--- a/farm/conversion/onnx_optimization/BertOnnxModel.py
+++ b/farm/conversion/onnx_optimization/BertOnnxModel.py
@@ -5,13 +5,18 @@
 #--------------------------------------------------------------------------
 
 import logging
-import onnx
 import sys
 import argparse
 import numpy as np
 from collections import deque
-from onnx import ModelProto, TensorProto, numpy_helper
 from .OnnxModel import OnnxModel
+
+try:
+    import onnx
+    from onnx import ModelProto, TensorProto, numpy_helper
+except:
+    pass
+
 
 logger = logging.getLogger(__name__)
 

--- a/farm/conversion/onnx_optimization/OnnxModel.py
+++ b/farm/conversion/onnx_optimization/OnnxModel.py
@@ -9,8 +9,12 @@ import sys
 import argparse
 import numpy as np
 from collections import deque
-import onnx
-from onnx import ModelProto, TensorProto, numpy_helper
+try:
+    import onnx
+    from onnx import ModelProto, TensorProto, numpy_helper
+except:
+    pass
+
 
 logger = logging.getLogger(__name__)
 

--- a/farm/conversion/onnx_optimization/bert_model_optimization.py
+++ b/farm/conversion/onnx_optimization/bert_model_optimization.py
@@ -25,17 +25,21 @@
 
 import logging
 # import coloredlogs
-import onnx
 import os
 import sys
 import argparse
 import numpy as np
 from collections import deque
-from onnx import ModelProto, TensorProto, numpy_helper
 from .BertOnnxModel import BertOnnxModel, BertOptimizationOptions
 # from .BertOnnxModelTF import BertOnnxModelTF
 # from BertOnnxModelKeras import BertOnnxModelKeras
 # from Gpt2OnnxModel import Gpt2OnnxModel
+
+try:
+    import onnx
+    from onnx import ModelProto, TensorProto, numpy_helper
+except:
+    pass
 
 logger = logging.getLogger('')
 


### PR DESCRIPTION
This PR adds exception handling if `onnx` is not installed, as it is an optional dependency.