### PR TITLE
Docstring Format fix

### DIFF
--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -426,9 +426,11 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
     def forward_lm(self, **kwargs):
         """
         Forward pass for the language model
+
         :param kwargs:
         :return:
         """
+
         # Check if we have to extract from a special layer of the LM (default = last layer)
         try:
             extraction_layer = self.language_model.extraction_layer

--- a/farm/train.py
+++ b/farm/train.py
@@ -42,11 +42,11 @@ class EarlyStopping:
         """
         :param save_dir: the directory where to save the final best model, if None, no saving.
         :param metric: name of dev set metric to monitor (default: loss) to get extracted from the 0th head or
-        a function that extracts a value from the trainer dev evaluation result.
-        NOTE: this is different from the metric to get specified for the processor which defines how
-        to calculate one or more evaluation matric values from prediction/target sets, while this
-        specifies the name of one particular such metric value or a method to calculate that value
-        from the result returned from a processor metric.
+                       a function that extracts a value from the trainer dev evaluation result.
+                       NOTE: this is different from the metric to get specified for the processor which defines how
+                       to calculate one or more evaluation matric values from prediction/target sets, while this
+                       specifies the name of one particular such metric value or a method to calculate that value
+                       from the result returned from a processor metric.
         :param mode: "min" or "max"
         :param patience: how many evaluations to wait after the best evaluation to stop
         :param min_delta: minimum difference to a previous best value to count as an improvement.
@@ -75,7 +75,7 @@ class EarlyStopping:
 
         :param eval: the current evaluation result
         :return: a tuple (stopprocessing, savemodel, evalvalue) indicating if processing should be stopped
-        and if the current model should get saved and the evaluation value used.
+                 and if the current model should get saved and the evaluation value used.
         """
 
         if isinstance(self.metric, str):

--- a/farm/train.py
+++ b/farm/train.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 
 class EarlyStopping:
+    """
+    Can be used to control early stopping with a Trainer class. Any object can be used instead which
+    implements the method check_stopping and and provides the attribute save_dir
+    """
 
     def __init__(
             self,
@@ -36,8 +40,6 @@ class EarlyStopping:
             min_evals=0,
     ):
         """
-        Can be used to control early stopping with a Trainer class. Any object can be used instead which
-        implements the method check_stopping and and provides the attribute save_dir
         :param save_dir: the directory where to save the final best model, if None, no saving.
         :param metric: name of dev set metric to monitor (default: loss) to get extracted from the 0th head or
         a function that extracts a value from the trainer dev evaluation result.
@@ -49,8 +51,8 @@ class EarlyStopping:
         :param patience: how many evaluations to wait after the best evaluation to stop
         :param min_delta: minimum difference to a previous best value to count as an improvement.
         :param min_evals: minimum number of evaluations to wait before using eval value
-
         """
+
         self.metric = metric
         self.save_dir = save_dir
         self.mode = mode

--- a/farm/train.py
+++ b/farm/train.py
@@ -72,10 +72,12 @@ class EarlyStopping:
         """
         Provide the evaluation value for the current evaluation. Returns true if stopping should occur.
         This will save the model, if necessary.
+
         :param eval: the current evaluation result
         :return: a tuple (stopprocessing, savemodel, evalvalue) indicating if processing should be stopped
         and if the current model should get saved and the evaluation value used.
         """
+
         if isinstance(self.metric, str):
             eval_value = eval_result[0][self.metric]
         else:


### PR DESCRIPTION
The docstring formatting has some small bugs. See here:

1. https://farm.deepset.ai/api/running.html#farm.train.EarlyStopping.__init__
2. https://farm.deepset.ai/api/running.html#farm.train.EarlyStopping.check_stopping
3. https://farm.deepset.ai/api/modeling.html#farm.modeling.adaptive_model.AdaptiveModel.forward_lm

The reason is that we need a blank line before the parameter section and the text section. This is fixed here. 