### PR TITLE
CI OOM Fix with smaller Model

### DIFF
--- a/test/test_lm_finetuning.py
+++ b/test/test_lm_finetuning.py
@@ -23,7 +23,7 @@ def test_lm_finetuning(caplog):
     n_epochs = 1
     batch_size = 1
     evaluate_every = 2
-    lang_model = "bert-base-cased"
+    lang_model = "distilbert-base-cased"
 
     tokenizer = Tokenizer.load(
         pretrained_model_name_or_path=lang_model, do_lower_case=False

--- a/test/test_question_answering.py
+++ b/test/test_question_answering.py
@@ -22,7 +22,7 @@ def test_qa(caplog=None):
     batch_size = 2
     n_epochs = 1
     evaluate_every = 4
-    base_LM_model = "distilbert-base-uncased"
+    base_LM_model = "albert-base-v2"
 
     tokenizer = Tokenizer.load(
         pretrained_model_name_or_path=base_LM_model, do_lower_case=True


### PR DESCRIPTION
CI is running OOM. See here #385 

This might be a fix. It is using a smaller model (`distilbert-base-cased` and `albert-base-v2`). See here: https://huggingface.co/transformers/pretrained_models.html