### PR TITLE
Managing pytorch pip find-links directive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 setuptools
 wheel
 # PyTorch
+--find-links=https://download.pytorch.org/whl/torch_stable.html
 torch==1.5.0
 # progress bars in model download and training scripts
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,47 @@ from io import open
 
 from setuptools import find_packages, setup
 
-with open("requirements.txt") as f:
-    parsed_requirements = f.read().splitlines()
-# remove blank lines and comments
-parsed_requirements = [
-    x.strip()
-    for x in parsed_requirements
-    if ((x.strip()[0] != "#") and (len(x.strip()) > 3) and "-e git://" not in x)
-]
 
+def parse_requirements(filename):
+    """
+    Parse a requirements pip file returning the list of required packages. It exclude commented lines and --find-links directives.
+
+    Args:
+        filename: pip requirements requirements
+
+    Returns:
+        list of required package with versions constraints
+
+    """
+    with open(filename) as file:
+        parsed_requirements = file.read().splitlines()
+    parsed_requirements = [line.strip()
+                           for line in parsed_requirements
+                           if not ((line.strip()[0] == "#") or line.strip().startswith('--find-links'))]
+    return parsed_requirements
+
+
+def get_dependency_links(filename):
+    """
+     Parse a requirements pip file looking for the --find-links directive.
+    Args:
+        filename:  pip requirements requirements
+
+    Returns:
+        list of find-links's url
+    """
+    with open(filename) as file:
+        parsed_requirements = file.read().splitlines()
+    dependency_links = list()
+    for line in parsed_requirements:
+        line = line.strip()
+        if line.startswith('--find-links'):
+            dependency_links.append(line.split('=')[1])
+    return dependency_links
+
+
+dependency_links = get_dependency_links('requirements.txt')
+parsed_requirements = parse_requirements('requirements.txt')
 
 setup(
     name="farm",
@@ -25,6 +57,7 @@ setup(
     url="https://gitlab.com/deepset-ai/ml/lm/farm",
     download_url="https://github.com/deepset-ai/FARM/archive/0.4.3.tar.gz",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    dependency_links=dependency_links,
     install_requires=parsed_requirements,
     python_requires=">=3.5.0",
     extras_require={


### PR DESCRIPTION
This is a solution for #366.

This solution includes:
 * the addition of  --find_links in the requirements.txt file (this is the suggested method also for Linux as suggested in https://pytorch.org/get-started/locally/)
 * the parsing of requirements.txt in setup.py to manage this new directive (https://stackoverflow.com/questions/57689387/equivalent-for-find-links-in-setup-py)

Note: I have not included in the new parsing function (parse_requirements) of the requirements.txt  the condition:
```python
if ((x.strip()[0] != "#") and (len(x.strip()) > 3) and "-e git://" not in x)
```
because I did not see its actual use . But if it is necessary we can add inside the parse_requirements function.

