### PR TITLE
Fix for CI problem - closing multiprocessing.pool again

### DIFF
--- a/farm/infer.py
+++ b/farm/infer.py
@@ -294,6 +294,12 @@ class Inferencer:
             log_ascii_workers(n=num_processes,logger=logger)
 
     def close_multiprocessing_pool(self):
+        """Close the `multiprocessing.Pool` again.
+
+        If you use multiprocessing you have to close the `multiprocessing.Pool` again!
+        To do so call this function after you are done using this class.
+        The garbage collector will not do this for you!
+        """
         if self.process_pool is not None:
             self.process_pool.close()
             self.process_pool = None

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -281,6 +281,11 @@ class Inferencer:
             )
             log_ascii_workers(n=num_processes,logger=logger)
 
+    def close_multiprocessing_pool(self):
+        if self.process_pool is not None:
+            self.process_pool.close()
+            self.process_pool = None
+
     def save(self, path):
         self.model.save(path)
         self.processor.save(path)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -84,7 +84,7 @@ class Inferencer:
                           (only needed for task_type="embeddings" and extraction_strategy = "s3e")
         :type s3e_stats: dict
         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
-                              multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
+                              multiprocessing. Set to None to let Inferencer use all CPU cores minus one. If you want to
                               debug the Language Model, you might need to disable multiprocessing!
                               **Warning!** If you use multiprocessing you have to close the
                               `multiprocessing.Pool` again! To do so call
@@ -177,7 +177,7 @@ class Inferencer:
                           (only needed for task_type="embeddings" and extraction_strategy = "s3e")
         :type s3e_stats: dict
         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
-                              multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
+                              multiprocessing. Set to None to let Inferencer use all CPU cores minus one. If you want to
                               debug the Language Model, you might need to disable multiprocessing!
                               **Warning!** If you use multiprocessing you have to close the
                               `multiprocessing.Pool` again! To do so call
@@ -272,7 +272,7 @@ class Inferencer:
         Initialize a multiprocessing.Pool for instances of Inferencer.
 
         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
-                              multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
+                              multiprocessing. Set to None to let Inferencer use all CPU cores minus one. If you want to
                               debug the Language Model, you might need to disable multiprocessing!
                               **Warning!** If you use multiprocessing you have to close the
                               `multiprocessing.Pool` again! To do so call

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -293,15 +293,20 @@ class Inferencer:
             )
             log_ascii_workers(n=num_processes,logger=logger)
 
-    def close_multiprocessing_pool(self):
+    def close_multiprocessing_pool(self, join=False):
         """Close the `multiprocessing.Pool` again.
 
         If you use multiprocessing you have to close the `multiprocessing.Pool` again!
         To do so call this function after you are done using this class.
         The garbage collector will not do this for you!
+
+        :param join: wait for the worker processes to exit
+        :type join: bool
         """
         if self.process_pool is not None:
             self.process_pool.close()
+            if join:
+                self.process_pool.join()
             self.process_pool = None
 
     def save(self, path):

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -86,6 +86,10 @@ class Inferencer:
         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
                               multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
                               debug the Language Model, you might need to disable multiprocessing!
+                              **Warning!** If you use multiprocessing you have to close the
+                              `multiprocessing.Pool` again! To do so call
+                              :func:`~farm.infer.Inferencer.close_multiprocessing_pool` after you are
+                              done using this class. The garbage collector will not do this for you!
         :type num_processes: int
         :param disable_tqdm: Whether to disable tqdm logging (can get very verbose in multiprocessing)
         :type disable_tqdm: bool
@@ -175,6 +179,10 @@ class Inferencer:
         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
                               multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
                               debug the Language Model, you might need to disable multiprocessing!
+                              **Warning!** If you use multiprocessing you have to close the
+                              `multiprocessing.Pool` again! To do so call
+                              :func:`~farm.infer.Inferencer.close_multiprocessing_pool` after you are
+                              done using this class. The garbage collector will not do this for you!
         :type num_processes: int
         :param disable_tqdm: Whether to disable tqdm logging (can get very verbose in multiprocessing)
         :type disable_tqdm: bool
@@ -263,9 +271,13 @@ class Inferencer:
         """
         Initialize a multiprocessing.Pool for instances of Inferencer.
 
-         :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
-                               multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
-                               debug the Language Model, you might need to disable multiprocessing!
+        :param num_processes: the number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
+                              multiprocessing. Set to None to let Inferencer use all CPU cores. If you want to
+                              debug the Language Model, you might need to disable multiprocessing!
+                              **Warning!** If you use multiprocessing you have to close the
+                              `multiprocessing.Pool` again! To do so call
+                              :func:`~farm.infer.Inferencer.close_multiprocessing_pool` after you are
+                              done using this class. The garbage collector will not do this for you!
         :type num_processes: int
         :return:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ dill # pickle extension for (de-)serialization
 # optional for inference
 #fasttext==0.9.1
 #onnxruntime  # Inference with ONNX models. Install onnxruntime-gpu for Inference on GPUs
+psutil

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import psutil
 import pytest
 
 from farm.infer import Inferencer
@@ -38,4 +39,13 @@ def adaptive_model_qa(use_gpu, num_processes):
         yield model
     finally:
         if num_processes != 0:
-            model.close_multiprocessing_pool()
+            # close the pool
+            # we pass join=True to wait for all sub processes to close
+            # this is because below we want to test if all sub-processes
+            # have exited
+            model.close_multiprocessing_pool(join=True)
+
+    # check if all workers (sub processes) are closed
+    current_process = psutil.Process()
+    children = current_process.children()
+    assert len(children) == 0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,11 +27,15 @@ def adaptive_model_qa(use_gpu, num_processes):
     """
     PyTest Fixture for a Question Answering Inferencer based on PyTorch.
     """
-    model = Inferencer.load(
-        "deepset/bert-base-cased-squad2",
-        task_type="question_answering",
-        batch_size=16,
-        num_processes=num_processes,
-        gpu=use_gpu,
-    )
-    return model
+    try:
+        model = Inferencer.load(
+            "deepset/bert-base-cased-squad2",
+            task_type="question_answering",
+            batch_size=16,
+            num_processes=num_processes,
+            gpu=use_gpu,
+        )
+        yield model
+    finally:
+        if num_processes != 0:
+            model.close_multiprocessing_pool()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,7 +23,7 @@ def pytest_generate_tests(metafunc):
             metafunc.parametrize("use_gpu", [False], scope="session")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def adaptive_model_qa(use_gpu, num_processes):
     """
     PyTest Fixture for a Question Answering Inferencer based on PyTorch.

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -5,10 +5,7 @@ from farm.infer import Inferencer
 
 @pytest.mark.parametrize("streaming", [True, False])
 @pytest.mark.parametrize("multiprocessing_chunksize", [None, 2])
-# TODO: Below is a TEMPORARY fix for CI problems caused by OOM caused by an unclosed worker pool.
-# see https://github.com/deepset-ai/FARM/pull/403
-#@pytest.mark.parametrize("num_processes", [2, 0, None], scope="session")
-@pytest.mark.parametrize("num_processes", [0], scope="session")
+@pytest.mark.parametrize("num_processes", [2, 0, None], scope="session")
 def test_qa_format_and_results(adaptive_model_qa, streaming, multiprocessing_chunksize):
     qa_inputs_dicts = [
         {


### PR DESCRIPTION
For the background of this PR see here and the following comments: https://github.com/deepset-ai/FARM/issues/385#issuecomment-640086021

## TODO

- [x] should we write a regression test with additional dependency to `psutil`? Details see below.
- [x] what about `num_processes = mp.cpu_count() - 1` vs. `num_processes = mp.cpu_count()`? Details see below.
- [x] write docstrings
- [ ] check examples and other documentation
- [ ] sould other code be changed to close pool