### PR TITLE
Add COVID-QA reproducibility

### DIFF
--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -27,6 +27,8 @@ DOWNSTREAM_TASK_MAP = {
     "germeval18": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/germeval18.tar.gz",
 
     "squad20": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/squad20.tar.gz",
+    "covidqa": "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-downstream/covidqa.tar.gz",
+
     "conll03detrain": "https://raw.githubusercontent.com/MaviccPRP/ger_ner_evals/master/corpora/conll2003/deu.train",
     "conll03dedev": "https://raw.githubusercontent.com/MaviccPRP/ger_ner_evals/master/corpora/conll2003/deu.testa", #https://www.clips.uantwerpen.be/conll2003/ner/000README says testa is dev data
     "conll03detest": "https://raw.githubusercontent.com/MaviccPRP/ger_ner_evals/master/corpora/conll2003/deu.testb",


### PR DESCRIPTION
- We open sourced a SQuAD style QA dataset on Covid related articles.
- We used cross validation in FARM on the COVID-QA data
- For details to the dataset see: https://github.com/deepset-ai/COVID-QA