### PR TITLE
Proper attribute assignment with yes / no answer

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1547,7 +1547,7 @@ class QuestionAnsweringHead(PredictionHead):
                 # i.e. if is_impossible
                 else:
                     cls_pred = "is_impossible"
-                pred_qa_answer.answer = cls_pred
+                pred_qa_answer.add_cls(cls_pred)
                 pred_qa_answers_new.append(pred_qa_answer)
             qa_doc_pred.prediction = pred_qa_answers_new
             ret.append(qa_doc_pred)

--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -77,18 +77,21 @@ class QACandidate:
         self.document_id = document_id
         self.passage_id = passage_id
 
-    def add_cls(self, c):
-        # Currently designed so that the QA head's prediction will always be preferred over the Classification head
-        if c in ["yes", "no"]:
-            if self.answer == "is_impossible":
-                pass
+    def add_cls(self, predicted_class: str):
+        """
+        Adjust the final QA prediction depending on the prediction of the classification head (e.g. for binary answers in NQ)
+        Currently designed so that the QA head's prediction will always be preferred over the Classification head
+
+        :param predicted_class: the predicted class value
+        :return: None
+        """
+
+        if predicted_class in ["yes", "no"] and self.answer != "is_impossible":
+            self.answer = predicted_class
+            self.answer_type = predicted_class
             self.answer_support = self.answer
-            self.answer = c
-            self.answer_type = c
-        elif c == "span":
-            pass
-        elif c == "is_impossible":
-            pass
+            self.offset_answer_support_start = self.offset_answer_start
+            self.offset_answer_support_end = self.offset_answer_end
 
     def to_doc_level(self, start, end):
         self.offset_answer_start = start

--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -77,6 +77,18 @@ class QACandidate:
         self.document_id = document_id
         self.passage_id = passage_id
 
+    def add_cls(self, c):
+        # Currently designed so that the QA head's prediction will always be preferred over the Classification head
+        if c in ["yes", "no"]:
+            if self.answer == "is_impossible":
+                pass
+            self.answer_support = self.answer
+            self.answer = c
+            self.answer_type = c
+        elif c == "span":
+            pass
+        elif c == "is_impossible":
+            pass
 
     def to_doc_level(self, start, end):
         self.offset_answer_start = start


### PR DESCRIPTION
This fixes an issue where QACandidate attributes were wrongly assigned when receiving a "yes" or "no" prediction from the text classification head