### PR TITLE
Fix Problematic QA Loop

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1267,7 +1267,7 @@ class QuestionAnsweringHead(PredictionHead):
 
             # Iterate over each prediction on the one document
             full_preds = []
-            for qa_answer, basket in zip(pred_d, baskets):
+            for qa_answer in pred_d:
                 # This should be a method of Span
                 pred_str, _, _ = span_to_string(qa_answer.offset_answer_start,
                                                 qa_answer.offset_answer_end,


### PR DESCRIPTION
Fixes a wrongly defined loop that impacts the number of candidates being returned per document. This solves [https://github.com/deepset-ai/haystack/issues/168](url)