### PR TITLE
WIP: Fix non increasing token_offsets

### DIFF
--- a/farm/modeling/tokenization.py
+++ b/farm/modeling/tokenization.py
@@ -279,9 +279,6 @@ def _words_to_tokens(words, word_offsets, tokenizer):
     idx = 0
     for w, w_off in zip(words, word_offsets):
         idx += 1
-        if idx % 500000 == 0:
-            logger.info(idx)
-        # Get (subword) tokens of single word.
 
         # empty / pure whitespace
         if len(w) == 0:
@@ -305,6 +302,9 @@ def _words_to_tokens(words, word_offsets, tokenizer):
         # get global offset for each token in word + save marker for first tokens of a word
         first_tok = True
         for tok in tokens_word:
+            if len(token_offsets) > 0:
+                if w_off < token_offsets[-1]:
+                    print()
             token_offsets.append(w_off)
             # Depending on the tokenizer type special chars are added to distinguish tokens with preceeding
             # whitespace (=> "start of a word"). We need to get rid of these to calculate the original length of the token

--- a/test/test_tokenization.py
+++ b/test/test_tokenization.py
@@ -117,6 +117,9 @@ def test_all_tokenizer_on_special_cases(caplog):
     "and another one\n\n\nwithout space",
     "This is a sentence	with tab",
     "This is a sentence			with multiple tabs",
+    """Mary is referred to by the Eastern Orthodox Church, Oriental Orthodoxy, the Anglican Church, and all Eastern Catholic Churches as Theotokos, a title recognized at the Third Ecumenical Council (held at Ephesus to address the teachings of Nestorius, in 431). Theotokos (and its Latin equivalents, "Deipara" and "Dei genetrix") literally means "Godbearer". The equivalent phrase "Mater Dei" (Mother of God) is more common in Latin and so also in the other languages used in the Western Catholic Church, but this same phrase in Greek (Μήτηρ Θεοῦ), in the abbreviated form of the first and last letter of the two words (ΜΡ ΘΥ), is the indication attached to her image in Byzantine icons. The Council stated that the Church Fathers "did not hesitate to speak of the holy Virgin as the Mother of God".""",
+    """The doctrine of pratītyasamutpāda, (Sanskrit; Pali: paticcasamuppāda; Tibetan Wylie: rten cing 'brel bar 'byung ba; Chinese: 緣起) is an important part of Buddhist metaphysics. It states that phenomena arise together in a mutually interdependent web of cause and effect. It is variously rendered into English as "dependent origination", "conditioned genesis", "dependent relationship", "dependent co-arising", "interdependent arising", or "contingency"."""
+
     ]
 
     for tokenizer in tokenizers:


### PR DESCRIPTION
This PR fixes the issue that tokenization of sentences containing special characters, especially characters from different languages, can cause token_offsets to contain non increasing offset indices. See test_tokenization.py for examples of problematic sentences.

This is caused by tokenizers' handling of unseen characters. RoBERTa's tokenizer sometimes turns one char into two (presumably through bit level encoding) and BERT converts some chars into "[UNK]" which is counted as 5 chars. 