### PR TITLE
WIP: Remove Asserts

### DIFF
--- a/farm/data_handler/dataloader.py
+++ b/farm/data_handler/dataloader.py
@@ -1,8 +1,10 @@
 from math import ceil
+import logging
 
 from torch.utils.data import DataLoader, Dataset, Sampler
 import torch
 
+logger = logging.getLogger(__name__)
 
 class NamedDataLoader(DataLoader):
     """
@@ -40,11 +42,10 @@ class NamedDataLoader(DataLoader):
             if type(batch[0]) == list:
                 batch = batch[0]
 
-            assert len(batch[0]) == len(
-                _tensor_names
-            ), "Dataset contains {} tensors while there are {} tensor names supplied: {}".format(
-                len(batch[0]), len(_tensor_names), _tensor_names
-            )
+            if len(batch[0]) != len(_tensor_names):
+                error_str = "Dataset contains {} tensors while there are {} tensor names supplied: {}".format(len(batch[0]), len(_tensor_names), _tensor_names)
+                logger.error(error_str)
+
             lists_temp = [[] for _ in range(len(_tensor_names))]
             ret = dict(zip(_tensor_names, lists_temp))
 

--- a/farm/data_handler/input_features.py
+++ b/farm/data_handler/input_features.py
@@ -70,10 +70,6 @@ def sample_to_features_text(
     input_ids = pad(input_ids, max_seq_len, tokenizer.pad_token_id, pad_on_left=pad_on_left)
     padding_mask = pad(padding_mask, max_seq_len, 0, pad_on_left=pad_on_left)
 
-    assert len(input_ids) == max_seq_len
-    assert len(padding_mask) == max_seq_len
-    assert len(segment_ids) == max_seq_len
-
     feat_dict = {
         "input_ids": input_ids,
         "padding_mask": padding_mask,

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1447,16 +1447,17 @@ class NaturalQuestionsProcessor(QAProcessor):
         if not short_answers:
             return "", -1
         short_answer_idxs = []
-        # TODO write comment explaining this
+        # Collect indices of all short answers and pick smallest and largest as start and end of new single span
         for short_answer in short_answers:
             short_answer_idxs.append(short_answer["start_token"])
             short_answer_idxs.append(short_answer["end_token"])
         answer_start_t = min(short_answer_idxs)
         answer_end_t = max(short_answer_idxs)
         answer_start_c, answer_end_c = self._convert_tok_to_ch(answer_start_t, answer_end_t, tok_to_ch, doc_text)
-        answer_text = doc_text[answer_start_c: answer_end_c]
-        assert answer_text == " ".join(doc_text.split()[answer_start_t: answer_end_t])
-        return answer_text, answer_start_c
+        answer_text_ch = doc_text[answer_start_c: answer_end_c]
+        answer_text_tok = " ".join(doc_text.split()[answer_start_t: answer_end_t])
+        assert answer_text_ch == answer_text_tok
+        return answer_text_ch, answer_start_c
 
     @staticmethod
     def _convert_tok_to_ch(start_t, end_t, tok_to_ch, doc_text):

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -45,7 +45,8 @@ def simple_accuracy(preds, labels):
     if type(preds) == type(labels) == list:
         preds = np.array(list(flatten_list(preds)))
         labels = np.array(list(flatten_list(labels)))
-    assert type(preds) == type(labels) == np.ndarray
+    if type(preds) != np.ndarray or type(labels) != np.ndarray:
+        logger.error("preds and labels should be of type np.ndarray")
     correct = preds == labels
     return {"acc": correct.mean()}
 
@@ -70,7 +71,8 @@ def pearson_and_spearman(preds, labels):
     }
 
 def compute_metrics(metric, preds, labels):
-    assert len(preds) == len(labels)
+    if len(preds) != len(labels):
+        logger.error("Length of preds does not match length of labels")
     if metric == "mcc":
         return {"mcc": matthews_corrcoef(labels, preds)}
     elif metric == "acc":

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -173,7 +173,8 @@ class LanguageModel(nn.Module):
             language_model.model.resize_token_embeddings(vocab_size)
             # verify
             model_emb_size = language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
-            assert vocab_size == model_emb_size
+            if vocab_size != model_emb_size:
+                logger.error("vocab_size does not equal model_embed_size")
 
         return language_model
 

--- a/farm/modeling/tokenization.py
+++ b/farm/modeling/tokenization.py
@@ -316,7 +316,6 @@ def _words_to_tokens(words, word_offsets, tokenizer):
             else:
                 start_of_word.append(False)
 
-    assert len(tokens) == len(token_offsets) == len(start_of_word)
     return tokens, token_offsets, start_of_word
 
 


### PR DESCRIPTION
The idea of this PR generally is to remove assertion statement so that running systems do not get interrupted by errors. What used to be asserts will, where appropriate, be converted into logging.error() or logging.warning(). 

This PR focuses only on QA related components. Asserts may still be present if they can be caught by try catch statements such as Processor._featurize_samples() or Processor._init_samples_in_baskets().