### PR TITLE
Upgrade pytorch and python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools
 wheel
 # PyTorch
 --find-links=https://download.pytorch.org/whl/torch_stable.html
-torch==1.5.0
+torch==1.5.1
 # progress bars in model download and training scripts
 tqdm
 # Accessing files from S3 directly.

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     dependency_links=dependency_links,
     install_requires=parsed_requirements,
-    python_requires=">=3.5.0",
+    python_requires=">=3.6.0",
     extras_require={
         "fasttext": ["fasttext==0.9.1"],
         "onnx": ["onnxruntime"],


### PR DESCRIPTION
- Pytorch 1.5.1 has quite some bugfixes. Don't see any reason to not upgrade. 
- To simplify maintenance in the future we should also rely on python >= 3.6 