### PR TITLE
Fix offset_end character for QA

### DIFF
--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -181,7 +181,7 @@ class QACandidate:
         final_text = clear_text[start_ch: end_ch].strip()
         end_ch = start_ch + len(final_text)
 
-        return clear_text[start_ch: end_ch].strip(), start_ch, end_ch
+        return final_text, start_ch, end_ch
 
     def add_cls(self, predicted_class: str):
         """

--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -177,6 +177,10 @@ class QACandidate:
             end_ch = len(clear_text)
         else:
             end_ch = token_offsets[end_t]
+
+        final_text = clear_text[start_ch: end_ch].strip()
+        end_ch = start_ch + len(final_text)
+
         return clear_text[start_ch: end_ch].strip(), start_ch, end_ch
 
     def add_cls(self, predicted_class: str):


### PR DESCRIPTION
Fixes a big in QA regarding end character calculation. If the extracted span is followed by a whitespace, the end_ch used to be one greater than it should be