### PR TITLE
Ensure QAInferencer always has task_type "question_answering"

### DIFF
--- a/farm/infer.py
+++ b/farm/infer.py
@@ -630,7 +630,7 @@ class QAInferencer(Inferencer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.task_type != "question_answering":
-            logger.warning("QAInferencer always has task_type='question_answer' even if another value is provided "
+            logger.warning("QAInferencer always has task_type='question_answering' even if another value is provided "
                            "to Inferencer.load() or QAInferencer()")
             self.task_type = "question_answering"
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -628,11 +628,11 @@ class Inferencer:
 
 class QAInferencer(Inferencer):
     def __init__(self, *args, **kwargs):
-        # Capture all input arguments, set "task_type" to "question_answering", initialize Inferencer class. The
-        # list slicing is to ensure that the "task_type" argument isn't passed in twice
-        args = args[:2]
-        kwargs["task_type"] = "question_answering"
         super().__init__(*args, **kwargs)
+        if self.task_type != "question_answering":
+            logger.warning("QAInferencer always has task_type='question_answer' even if another value is provided "
+                           "to Inferencer.load() or QAInferencer()")
+            self.task_type = "question_answering"
 
     def inference_from_dicts(self,
                              dicts,

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -627,6 +627,12 @@ class Inferencer:
 
 
 class QAInferencer(Inferencer):
+    def __init__(self, *args, **kwargs):
+        # Capture all input arguments, set "task_type" to "question_answering", initialize Inferencer class. The
+        # list slicing is to ensure that the "task_type" argument isn't passed in twice
+        args = args[:2]
+        kwargs["task_type"] = "question_answering"
+        super().__init__(*args, **kwargs)
 
     def inference_from_dicts(self,
                              dicts,


### PR DESCRIPTION
Though the parent Inferencer class can set task_type to one of many values, it should always be "question_answering" in the QAInferencer. This PR enforces this and gives a warning when a user tries to initialise the class with a different value