### PR TITLE
Remove assertions or replace with logging error

### DIFF
--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -158,7 +158,8 @@ class QACandidate:
         :return: The string answer span, followed by the start and end character indices
         """
 
-        assert self.offset_unit == "token"
+        if self.offset_unit != "token":
+            logger.error(f"QACandidate needs to have self.offset_unit=token before calling _span_to_string() (id = {self.id})")
 
         start_t = self.offset_answer_start
         end_t = self.offset_answer_end

--- a/farm/modeling/tokenization.py
+++ b/farm/modeling/tokenization.py
@@ -317,7 +317,6 @@ def _words_to_tokens(words, word_offsets, tokenizer):
             else:
                 start_of_word.append(False)
 
-    assert len(tokens) == len(token_offsets) == len(start_of_word)
     return tokens, token_offsets, start_of_word
 
 


### PR DESCRIPTION
This PR either removes asserts or replaces them with logging errors. The idea behind this is to improve the stability of FARM in production so that it doesn't crash halfway through a long inference or training job. Asserts that check initialization of components are maintained.