### PR TITLE
Propagate QA ground truth in Inferencer

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1284,8 +1284,8 @@ class NaturalQuestionsProcessor(QAProcessor):
         mapping from document to question. Input dictionaries can have either ["context", "qas"] (internal format) as
         keys or ["text", "questions"] (api format). Both are supported.
         """
-        # Turns a NQ dictionaries into a SQuAD style dictionaries
-        if not self.inference:
+        # Turns NQ dictionaries into a SQuAD style dictionaries
+        if self._is_nq_dict(dictionary):
             dictionary = self._prepare_dict(dictionary=dictionary)
 
         dictionary_tokenized = _apply_tokenization(dictionary, self.tokenizer)[0]
@@ -1300,6 +1300,12 @@ class NaturalQuestionsProcessor(QAProcessor):
         if not self.inference:
             samples = self._downsample(samples, self.keep_no_answer)
         return samples
+
+    @staticmethod
+    def _is_nq_dict(dictionary):
+        if set(dictionary.keys()) == {'document_text', 'long_answer_candidates', 'question_text', 'annotations', 'document_url', 'example_id'}:
+            return True
+        return False
 
     def _downsample(self, samples, keep_prob):
         # Downsamples samples with a no_answer label (since there is an overrepresentation of these in NQ)

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1263,9 +1263,9 @@ class QuestionAnsweringHead(PredictionHead):
     @staticmethod
     def get_ground_truth(basket):
         if "answers" in basket.raw:
-            return basket.raw["answer"]
+            return basket.raw["answers"]
         elif "annotations" in basket.raw:
-            return basket.raw["annoations"]
+            return basket.raw["annotations"]
         else:
             return None
 

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1262,10 +1262,12 @@ class QuestionAnsweringHead(PredictionHead):
 
     @staticmethod
     def get_ground_truth(basket):
-        try:
-            return basket.raw["answers"]
-        except KeyError:
-            return basket.raw["annotations"]
+        if "answers" in basket.raw:
+            return basket.raw["answer"]
+        elif "annotations" in basket.raw:
+            return basket.raw["annoations"]
+        else:
+            return None
 
     @staticmethod
     def get_question(question_names, raw_dict):

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1245,6 +1245,7 @@ class QuestionAnsweringHead(PredictionHead):
 
             document_text = try_get(doc_names, basket.raw)
             question = self.get_question(question_names, basket.raw)
+            ground_truth = self.get_ground_truth(basket)
 
             curr_doc_pred = QAPred(id=pred_id,
                                    prediction=pred_d,
@@ -1253,10 +1254,18 @@ class QuestionAnsweringHead(PredictionHead):
                                    token_offsets=token_offsets,
                                    context_window_size=self.context_window_size,
                                    aggregation_level="document",
+                                   ground_truth_answer=ground_truth,
                                    no_answer_gap=no_ans_gap)
 
             ret.append(curr_doc_pred)
         return ret
+
+    @staticmethod
+    def get_ground_truth(basket):
+        try:
+            return basket.raw["answers"]
+        except KeyError:
+            return basket.raw["annotations"]
 
     @staticmethod
     def get_question(question_names, raw_dict):


### PR DESCRIPTION
This PR adds propagation of QA ground truth labels through the Inferencer, whether in SQuAD or Natural Questions style. 