### PR TITLE
Remove rest_api_schema argument in inference_from_dicts()

### DIFF
--- a/examples/conversion_huggingface_models.py
+++ b/examples/conversion_huggingface_models.py
@@ -22,7 +22,7 @@ def convert_from_transformers():
     # run predictions
     QA_input = [{"questions": ["Why is model conversion important?"],
                  "text": "The option to convert models between FARM and transformers gives freedom to the user and let people easily switch between frameworks."}]
-    result = nlp.inference_from_dicts(dicts=QA_input, rest_api_schema=True)
+    result = nlp.inference_from_dicts(dicts=QA_input)
     pprint.pprint(result)
     nlp.close_multiprocessing_pool()
 

--- a/examples/conversion_huggingface_models_classification.py
+++ b/examples/conversion_huggingface_models_classification.py
@@ -24,7 +24,7 @@ def convert_from_transformers():
     nlp = Inferencer.load(transformers_input_name, task_type="text_classification")
     #
     # # run predictions
-    result = nlp.inference_from_dicts(dicts=[{"text": "Was ein scheiß Nazi!"}], rest_api_schema=True)
+    result = nlp.inference_from_dicts(dicts=[{"text": "Was ein scheiß Nazi!"}])
     pprint.pprint(result)
     nlp.close_multiprocessing_pool()
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -518,10 +518,6 @@ class Inferencer:
         :param baskets: For each item in the dataset, we need additional information to create formatted preds.
                         Baskets contain all relevant infos for that.
                         Example: QA - input string to convert the predicted answer from indices back to string space
-        :param rest_api_schema: Whether input dicts use the format that complies with the FARM REST API.
-                                Currently only used for QA to switch from squad to a more useful format in production.
-                                While input is almost the same, output contains additional meta data(offset, context..)
-        :type rest_api_schema: bool
         :return: list of predictions
         """
         samples = [s for b in baskets for s in b.samples]

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -555,10 +555,6 @@ class Inferencer:
         :param baskets: For each item in the dataset, we need additional information to create formatted preds.
                         Baskets contain all relevant infos for that.
                         Example: QA - input string to convert the predicted answer from indices back to string space
-        :param rest_api_schema: Whether input dicts use the format that complies with the FARM REST API.
-                                Currently only used for QA to switch from squad to a more useful format in production.
-                                While input is almost the same, output contains additional meta data(offset, context..)
-        :type rest_api_schema: bool
         :return: list of predictions
         """
 

--- a/farm/inference_rest_api.py
+++ b/farm/inference_rest_api.py
@@ -84,7 +84,7 @@ class InferenceEndpoint(Resource):
         dicts = request.get_json().get("input", None)
         if not dicts:
             return {}
-        results = model.inference_from_dicts(dicts=dicts, rest_api_schema=True)
+        results = model.inference_from_dicts(dicts=dicts)
         return results[0]
 
 


### PR DESCRIPTION
Removes traces of an old argument that could be passed in to Inferencer.inference_from_dicts()

