### PR TITLE
Remove torch version wildcard in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools
 wheel
 # PyTorch
 --find-links=https://download.pytorch.org/whl/torch_stable.html
-torch==1.5.*
+torch==1.5.1
 # progress bars in model download and training scripts
 tqdm
 # Accessing files from S3 directly.


### PR DESCRIPTION
`*` in torch version seems to break installation on Windows OS.

Related issue: https://github.com/deepset-ai/FARM/issues/485, https://github.com/deepset-ai/haystack/issues/289