### PR TITLE
Download models from (private) S3

### DIFF
--- a/farm/file_utils.py
+++ b/farm/file_utils.py
@@ -105,11 +105,14 @@ def download_from_s3(s3_url: str, cache_dir: str = "~/.cache/torch/farm"):
     :return: local path of the folder
     """
 
+    logger.info(f"Downloading from {s3_url}")
     s3_resource = boto3.resource('s3')
     bucket_name, s3_path = split_s3_path(s3_url)
     bucket = s3_resource.Bucket(bucket_name)
     objects = bucket.objects.filter(Prefix=s3_path)
-    logger.info(f"Downloading from {s3_url}")
+    if not objects:
+        raise ValueError("Could not find s3_url: {s3_url}")
+
     for obj in objects:
         path, filename = os.path.split(obj.key)
         path = os.path.join(cache_dir, path)

--- a/farm/file_utils.py
+++ b/farm/file_utils.py
@@ -96,16 +96,19 @@ def filename_to_url(filename, cache_dir=None):
     return url, etag
 
 
-def download_from_s3(s3_url: str, cache_dir: str = "~/.cache/torch/farm"):
+def download_from_s3(s3_url: str, cache_dir: str = None):
     """
     Download a "folder" from s3 to local. Skip already existing files. Useful for downloading all files of one model
 
     :param s3_url: Url of the "folder" in s3 (e.g. s3://mybucket/my_modelname)
-    :param cache_dir: local directory where the files shall be stored
+    :param cache_dir: Optional local directory where the files shall be stored.
+                      If not supplied, we'll use a subfolder in torch's cache dir (~/.cache/torch/farm)
     :return: local path of the folder
     """
 
     logger.info(f"Downloading from {s3_url}")
+    if cache_dir is None:
+        cache_dir = os.path.join(torch_cache_home, "farm")
     s3_resource = boto3.resource('s3')
     bucket_name, s3_path = split_s3_path(s3_url)
     bucket = s3_resource.Bucket(bucket_name)

--- a/farm/file_utils.py
+++ b/farm/file_utils.py
@@ -108,7 +108,7 @@ def download_from_s3(s3_url: str, cache_dir: str = None):
 
     logger.info(f"Downloading from {s3_url}")
     if cache_dir is None:
-        cache_dir = os.path.join(torch_cache_home, "farm")
+        cache_dir = default_cache_path
     s3_resource = boto3.resource('s3')
     bucket_name, s3_path = split_s3_path(s3_url)
     bucket = s3_resource.Bucket(bucket_name)

--- a/farm/file_utils.py
+++ b/farm/file_utils.py
@@ -108,7 +108,7 @@ def download_from_s3(s3_url: str, cache_dir: str = None):
 
     logger.info(f"Downloading from {s3_url}")
     if cache_dir is None:
-        cache_dir = default_cache_path
+        cache_dir = FARM_CACHE
     s3_resource = boto3.resource('s3')
     bucket_name, s3_path = split_s3_path(s3_url)
     bucket = s3_resource.Bucket(bucket_name)


### PR DESCRIPTION
Simple utility function to download a model from an s3 bucket (e.g. private AWS or on-prem deployment).
We'll skip those files that have already been downloaded before.

Usage: 

```python
from farm.modeling.tokenization import Tokenizer
from farm.modeling.language_model import LanguageModel
from farm.file_utils import download_from_s3

# download model (if no custom cache_dir is supplied => we use FARM default cache dir, i.e. ~/.cache/torch/farm on Linux)
remote_model_path = "s3://your_bucket/bert-base-german-cased/"
local_model_path = download_from_s3(s3_url=remote_model_path, cache_dir=None)

# load components as usual
tokenizer = Tokenizer.load(local_model_path)
language_model = LanguageModel.load(local_model_path)
```

Potential improvements in the future:
- add a file with the hash to see if remote files have been updated and therefore need to be downloaded again
- progress bar for download
