### PR TITLE
fix Natural Question inference processing

### DIFF
--- a/examples/natural_questions.py
+++ b/examples/natural_questions.py
@@ -35,7 +35,7 @@ def question_answering():
     evaluate_every = 500
     lang_model = "deepset/roberta-base-squad2" # start with a model that can already extract answers
     do_lower_case = False # roberta is a cased model
-    train_filename = "train_medium.jsonl"
+    train_filename = "dev_medium.jsonl"
     dev_filename = "dev_medium.jsonl"
     keep_is_impossible = 0.15 # downsample negative examples after data conversion
     downsample_context_size = 300 # reduce length of wikipedia articles to relevant part around the answer
@@ -136,7 +136,7 @@ def question_answering():
 
     print(f"\nQuestion: Did GameTrailers rated Twilight Princess as one of the best games ever created?"
           f"\nAnswer from model: {result[0].prediction[0].answer}")
-    model.close_multiprcessing_pool()
+    model.close_multiprocessing_pool()
 
 if __name__ == "__main__":
     question_answering()

--- a/examples/natural_questions.py
+++ b/examples/natural_questions.py
@@ -35,7 +35,7 @@ def question_answering():
     evaluate_every = 500
     lang_model = "deepset/roberta-base-squad2" # start with a model that can already extract answers
     do_lower_case = False # roberta is a cased model
-    train_filename = "dev_medium.jsonl"
+    train_filename = "train_medium.jsonl"
     dev_filename = "dev_medium.jsonl"
     keep_is_impossible = 0.15 # downsample negative examples after data conversion
     downsample_context_size = 300 # reduce length of wikipedia articles to relevant part around the answer

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -427,12 +427,15 @@ def stack(list_of_lists):
 
 
 def try_get(keys, dictionary):
-    for key in keys:
-        if key in dictionary:
-            ret = dictionary[key]
-            if type(ret) == list:
-                ret = ret[0]
-            return ret
+    try:
+        for key in keys:
+            if key in dictionary:
+                ret = dictionary[key]
+                if type(ret) == list:
+                    ret = ret[0]
+                return ret
+    except Exception as e:
+        logger.warning(f"Cannot extract from dict {dictionary} with error: {e}")
     return None
 
 class Benchmarker:


### PR DESCRIPTION
When extracting IDs from the input we run into errors.

This is a quick fix catching the exception, since we do not need these IDs. 
We should investigate for a better solution and create NQ test cases for training and inferencing @brandenchan 