### PR TITLE
auto lowercase: set lower case based on model name

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -197,7 +197,17 @@ class Processor(ABC):
         if "lower_case" in config.keys():
             logger.warning("Loading tokenizer from deprecated FARM config. "
                            "If you used `custom_vocab` or `never_split_chars`, this won't work anymore.")
-            tokenizer = Tokenizer.load(load_dir, tokenizer_class=config["tokenizer"], do_lower_case=config["lower_case"])
+                           
+            # automatically estimate lowercase model based on the model name
+            if config["lower_case"] == 'auto':
+                if 'uncased' in config["model"]:
+                    lower_case=True
+                else:
+                    lower_case=False
+            else:
+                lower_case = config["lower_case"]
+
+            tokenizer = Tokenizer.load(load_dir, tokenizer_class=config["tokenizer"], do_lower_case=lower_case)
         else:
             tokenizer = Tokenizer.load(load_dir, tokenizer_class=config["tokenizer"])
 

--- a/farm/experiment.py
+++ b/farm/experiment.py
@@ -57,9 +57,18 @@ def run_experiment(args):
 
     set_all_seeds(args.general.seed)
 
+    # automatically estimate lowercase model based on the model name
+    if args.parameter.lower_case == 'auto':
+        if 'uncased' in args.parameter.model:
+            lower_case=True
+        else:
+            lower_case=False
+    else:
+        lower_case = args.parameter.lower_case
+
     # Prepare Data
     tokenizer = Tokenizer.load(
-        args.parameter.model, do_lower_case=args.parameter.lower_case
+        args.parameter.model, do_lower_case=lower_case
     )
 
     processor = Processor.load(


### PR DESCRIPTION
added the possibility to let the framework estimate lowercase modules from the module name. I observed the unwritten standard, that lowercase modules contain `uncased` in the name. In order to mix uncased and cased in one experiment file, this feature was added. Simply set `lower_case` to `"auto"` in the experiment json file. 