### PR TITLE
Add asserts on doc_stride and max_seq_len to prevent issues with sliding window

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1137,6 +1137,10 @@ class SquadProcessor(QAProcessor):
         self.target = "classification"
         self.ph_output_type = "per_token_squad"
 
+        assert doc_stride < max_seq_len, "doc_stride is longer than max_seq_len. This means that there will be gaps " \
+                                         "as the passage windows slide, causing the model to skip over parts of the document. "\
+                                         "Please set a lower value for doc_stride (Suggestions: doc_stride=128, max_seq_len=384) "
+
         self.doc_stride = doc_stride
         self.max_query_length = max_query_length
         self.max_answers = max_answers

--- a/farm/data_handler/samples.py
+++ b/farm/data_handler/samples.py
@@ -219,6 +219,11 @@ def chunk_into_passages(doc_offsets,
                         doc_text):
     """ Returns a list of dictionaries which each describe the start, end and id of a passage
     that is formed when chunking a document using a sliding window approach. """
+
+    assert doc_stride < passage_len_t, "doc_stride is longer than passage_len_t. This means that there will be gaps " \
+                                       "as the passage windows slide, causing the model to skip over parts of the document. "\
+                                       "Please set a lower value for doc_stride (Suggestions: doc_stride=128, max_seq_len=384) "
+
     passage_spans = []
     passage_id = 0
     doc_len_t = len(doc_offsets)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -252,6 +252,9 @@ class Inferencer:
             # override processor attributes loaded from config file with inferencer params
             processor.max_seq_len = max_seq_len
             if hasattr(processor, "doc_stride"):
+                assert doc_stride < max_seq_len, "doc_stride is longer than max_seq_len. This means that there will be gaps " \
+                                                 "as the passage windows slide, causing the model to skip over parts of the document. "\
+                                                 "Please set a lower value for doc_stride (Suggestions: doc_stride=128, max_seq_len=384) "
                 processor.doc_stride = doc_stride
 
         # b) or from remote transformers model hub


### PR DESCRIPTION
In cases where the doc_stride is greater than the number of passage tokens in the sliding window, an index error may be thrown. See #536 and #510. This PR adds asserts to avoid these situations.  

Note that the number of passage tokens is computed as follows:
max_seq_len - question_tokens - special tokens