### PR TITLE
Relax torch versions & Bump FARM version to 0.4.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools
 wheel
 # PyTorch
 --find-links=https://download.pytorch.org/whl/torch_stable.html
-torch>=1.5.1,<=1.6.0
+torch>1.5,<1.7
 # progress bars in model download and training scripts
 tqdm
 # Accessing files from S3 directly.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ parsed_requirements = parse_requirements('requirements.txt')
 
 setup(
     name="farm",
-    version="0.4.8",
+    version="0.4.9",
     author="Malte Pietsch, Timo Moeller, Branden Chan, Tanay Soni",
     author_email="malte.pietsch@deepset.ai",
     description="Toolkit for finetuning and evaluating transformer based language models",
@@ -55,7 +55,7 @@ setup(
     keywords="BERT NLP deep learning language-model transformer qa question-answering transfer-learning",
     license="Apache",
     url="https://gitlab.com/deepset-ai/ml/lm/farm",
-    download_url="https://github.com/deepset-ai/FARM/archive/0.4.8.tar.gz",
+    download_url="https://github.com/deepset-ai/FARM/archive/0.4.9.tar.gz",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     dependency_links=dependency_links,
     install_requires=parsed_requirements,


### PR DESCRIPTION
Installing FARM in environments where torch's GPU version was already installed via pip (e.g. torch 1.6.0+cu101), caused version mismatches and requiired manual reinstallation. This is especially annoying in Google Colab environments. 

Change: Allow all torch 1.6.x versions incl 1.6.0+cu101 etc