### PR TITLE
Fixed conversion of BertForMaskedLM to transformers

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -720,6 +720,8 @@ class BertLMHead(PredictionHead):
         self.vocab_size = vocab_size
         self.loss_fct = CrossEntropyLoss(reduction="none", ignore_index=-1)
         self.num_labels = vocab_size  # vocab size
+        # Adding layer_dims (required for conversion to transformers)
+        self.layer_dims = [hidden_size, vocab_size]
         # TODO Check if weight init needed!
         # self.apply(self.init_bert_weights)
         self.ph_output_type = "per_token"


### PR DESCRIPTION
Fix for issue #533 

Made the following changes:

1. Added `layer_dims` attribute in FARM's BertLMHead class as described in the issue.
2. Added check for the conversion of AdaptiveModel with 2 prediction heads (where the first prediction head is "language_modelling") in `AdaptiveModel.convert_to_transformers()`