### PR TITLE
Add passages per second calculation to benchmarks

### DIFF
--- a/test/benchmarks/question_answering_components.py
+++ b/test/benchmarks/question_answering_components.py
@@ -25,8 +25,8 @@ params = {
     "modelname": ["deepset/bert-base-cased-squad2", "deepset/minilm-uncased-squad2", "deepset/roberta-base-squad2", "deepset/bert-large-uncased-whole-word-masking-squad2", "deepset/xlm-roberta-large-squad2"],
     "batch_size": [50],
     "document_size": [1000_000],
-    "max_seq_len": [384],
-    "doc_stride": [128],
+    "max_seq_len": [384],       # This param needs to be set to 384 otherwise the "passages per sec" calculation will be wrong
+    "doc_stride": [128],        # This param needs to be set to 128 otherwise the "passages per sec" calculation will be wrong
     "gpu": [True],
     "question": [l[:-1] for l in open(questions_file)][:2]
 }

--- a/test/benchmarks/question_answering_components.py
+++ b/test/benchmarks/question_answering_components.py
@@ -9,6 +9,7 @@ from pprint import pformat
 import pandas as pd
 from tqdm import tqdm
 import logging
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -17,18 +18,20 @@ task_type = "question_answering"
 sample_file = "samples/question_answering_sample.txt"
 questions_file = "samples/question_answering_questions.txt"
 num_processes = 1
+passages_per_char = 2400 / 1000000      # numerator is number of passages when 1mill chars paired with one of the questions, msl 384, doc stride 128
+output_file = "results_component_test_24_09_20.csv"
 
 params = {
     "modelname": ["deepset/bert-base-cased-squad2", "deepset/minilm-uncased-squad2", "deepset/roberta-base-squad2", "deepset/bert-large-uncased-whole-word-masking-squad2", "deepset/xlm-roberta-large-squad2"],
-    "batch_size": [16, 32, 64],
-    "document_size": [10_000, 100_000, 1000_000],
-    "max_seq_len": [384, 512],
+    "batch_size": [50],
+    "document_size": [1000_000],
+    "max_seq_len": [384],
     "doc_stride": [128],
     "gpu": [True],
     "question": [l[:-1] for l in open(questions_file)][:2]
 }
 
-def benchmark(params, output="results_component_test.csv"):
+def benchmark(params, output=output_file):
     ds = generate_param_dicts(params)
     print(f"Running {len(ds)} benchmarks...")
     results = []
@@ -36,9 +39,9 @@ def benchmark(params, output="results_component_test.csv"):
     for d in tqdm(ds):
         result = benchmark_single(**d)
         results.append(result)
+        df = pd.DataFrame.from_records(results)
+        df.to_csv(output)
         logger.info("\n\n" + pformat(result) + "\n")
-    df = pd.DataFrame.from_records(results)
-    df.to_csv(output)
 
 
 def warmup_run():
@@ -97,6 +100,7 @@ def benchmark_single(batch_size, gpu, max_seq_len, doc_stride, document_size, qu
                   "language model": lm_time,
                   "prediction head": ph_time,
                   "total": total,
+                  "passages per sec": (document_size * passages_per_char) / total,
                   "batch_size": batch_size,
                   "document_size": document_size,
                   "num_processes": num_processes,
@@ -115,6 +119,7 @@ def benchmark_single(batch_size, gpu, max_seq_len, doc_stride, document_size, qu
                   "language model": -1,
                   "prediction head": -1,
                   "total": -1,
+                  "passages_per_sec": -1,
                   "batch_size": batch_size,
                   "document_size": document_size,
                   "num_processes": num_processes,
@@ -149,9 +154,16 @@ def recurse(param_names, state, result):
 
 def prepare_dict(sample_file, q, document_size):
     with open(sample_file) as f:
-        text = f.read()[:document_size]
-        assert len(text) == document_size
-    dicts = [{"qas": [q], "context": text}]
+        if sample_file[-3:] == "txt":
+            text = f.read()[:document_size]
+            assert len(text) == document_size
+            dicts = [{"qas": [q], "context": text}]
+        elif sample_file[-4:] == "json":
+            data = json.load(f)
+            dicts = []
+            for d in data["data"]:
+                for p in d["paragraphs"]:
+                    dicts.append(p)
     return dicts
 
 


### PR DESCRIPTION
Running the per component benchmark now returns a measurement of passages processed per second