### PR TITLE
Fix random behavior when loading ELECTRA models

### DIFF
--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -1275,6 +1275,7 @@ class Electra(LanguageModel):
         config.summary_last_dropout = 0
         config.summary_type = 'first'
         config.summary_activation = 'gelu'
+        config.summary_use_proj = False
         electra.pooler = SequenceSummary(config)
         electra.pooler.apply(electra.model._init_weights)
         return electra


### PR DESCRIPTION
This PR should fix #519. @brandenchan @stefan-it @PhilipMay 

### Summary of the bug
When training an ELECTRA model, saving it and loading it later on, the loaded model produced different (much worse) predictions than the trained model.

### Root of the bug
In this [transformers PR](https://github.com/huggingface/transformers/pull/4954), `summary_use_proj` was set by default to `True`, which means that a linear layer is stacked on top of pooling. Therefore, each time an ELECTRA model is loaded in FARM, the weights of this linear layer are randomly initialized.

### Fix
Set `summary_use_proj` to `False` in order to not add that linear layer.