### PR TITLE
Refactor DPR modeling for multigpu training

### DIFF
--- a/examples/dpr_encoder.py
+++ b/examples/dpr_encoder.py
@@ -30,7 +30,7 @@ def dense_passage_retrieval():
     ##########################
     set_all_seeds(seed=42)
     device, n_gpu = initialize_device_settings(use_cuda=True)
-    batch_size = 2 # For MultiGPU Training via DataParallel: Only use multiples of 2 to ensure similar batches
+    batch_size = 2
     n_epochs = 3
     evaluate_every = 1000
     question_lang_model = "facebook/dpr-question_encoder-single-nq-base"
@@ -42,6 +42,7 @@ def dense_passage_retrieval():
     similarity_function = "dot_product"
     train_filename = "nq-train.json"
     dev_filename = "nq-dev.json"
+    max_samples = None #load a smaller dataset (e.g. for debugging)
 
     # 1.Create question and passage tokenizers
     query_tokenizer = Tokenizer.load(pretrained_model_name_or_path=question_lang_model,
@@ -59,13 +60,13 @@ def dense_passage_retrieval():
                              max_seq_len=256,
                              label_list=label_list,
                              metric=metric,
-                             data_dir="../../DPR/data/retriever",
+                             data_dir="data/retriever",
                              train_filename=train_filename,
                              dev_filename=dev_filename,
                              test_filename=dev_filename,
                              embed_title=embed_title,
                              num_hard_negatives=num_hard_negatives,
-                             max_samples=10)
+                             max_samples=max_samples)
 
     # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
     # NOTE: In FARM, the dev set metrics differ from test set metrics in that they are calculated on a token level instead of a word level

--- a/examples/dpr_encoder.py
+++ b/examples/dpr_encoder.py
@@ -30,7 +30,7 @@ def dense_passage_retrieval():
     ##########################
     set_all_seeds(seed=42)
     device, n_gpu = initialize_device_settings(use_cuda=True)
-    batch_size = 2
+    batch_size = 2 # For MultiGPU Training via DataParallel: Only use multiples of 2 to ensure similar batches
     n_epochs = 3
     evaluate_every = 1000
     question_lang_model = "facebook/dpr-question_encoder-single-nq-base"
@@ -56,15 +56,16 @@ def dense_passage_retrieval():
     metric = "text_similarity_metric"
     processor = TextSimilarityProcessor(tokenizer=query_tokenizer,
                              passage_tokenizer=context_tokenizer,
-                             max_seq_len=512,
+                             max_seq_len=256,
                              label_list=label_list,
                              metric=metric,
-                             data_dir="data/retriever",
+                             data_dir="../../DPR/data/retriever",
                              train_filename=train_filename,
                              dev_filename=dev_filename,
                              test_filename=dev_filename,
                              embed_title=embed_title,
-                             num_hard_negatives=num_hard_negatives)
+                             num_hard_negatives=num_hard_negatives,
+                             max_samples=10)
 
     # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
     # NOTE: In FARM, the dev set metrics differ from test set metrics in that they are calculated on a token level instead of a word level

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1956,7 +1956,7 @@ class TextSimilarityProcessor(Processor):
         {"text": document_text, "title": xxx, "label": "hard_negative", "external_id": abb134},
         ...]}
         """
-        dicts = read_dpr_json(file)
+        dicts = read_dpr_json(file, max_samples=self.max_samples)
         return dicts
 
     def _normalize_question(self, question: str) -> str:

--- a/farm/data_handler/utils.py
+++ b/farm/data_handler/utils.py
@@ -183,7 +183,7 @@ def read_ner_file(filename, sep="\t", proxies=None):
         data.append({"text": " ".join(sentence), "ner_label": label})
     return data
 
-def read_dpr_json(file, proxies=None):
+def read_dpr_json(file, max_samples=None, proxies=None):
     """
     Reads a Dense Passage Retrieval (DPR) data file in json format and returns a list of dictionaries.
 
@@ -215,7 +215,8 @@ def read_dpr_json(file, proxies=None):
         logger.info(f" Couldn't find {file} locally. Trying to download ...")
         _download_extract_downstream_data(file, proxies=proxies)
     dicts = json.load(open(file))
-
+    if max_samples:
+        dicts = random.sample(dicts, min(max_samples, len(dicts)))
     # convert DPR dictionary to standard dictionary
     query_json_keys = ["question", "questions", "query"]
     positive_context_json_keys = ["positive_contexts", "positive_ctxs", "positive_context", "positive_ctx"]

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1670,7 +1670,7 @@ class TextSimilarityHead(PredictionHead):
         positive_idx_per_question = torch.nonzero((lm_label_ids.view(-1) == 1), as_tuple=False)
         #TODO gather global tensors from all nodes for DDP
         global_positive_idx_per_question = positive_idx_per_question
-        targets = global_positive_idx_per_question.squeeze(-1).to(logits.device)
+        targets = global_positive_idx_per_question.squeeze(-1).to(softmax_scores.device)
 
         # Calculate loss
         loss = self.loss_fct(softmax_scores, targets)

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1615,7 +1615,7 @@ class TextSimilarityHead(PredictionHead):
         elif "cosine" in self.similarity_function:
             return TextSimilarityHead.cosine_scores
 
-    def forward(self, query_vectors:torch.Tensor, context_vectors:torch.Tensor) -> Tuple[torch.Tensor]:
+    def forward(self, query_vectors:torch.Tensor, context_vectors:torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Only packs the embeddings from both language models into a tuple. No further modification.
         The similarity calculation is handled later to enable distributed training (DDP)
@@ -1654,7 +1654,7 @@ class TextSimilarityHead(PredictionHead):
         softmax_scores = nn.functional.log_softmax(scores, dim=1)
         return softmax_scores
 
-    def logits_to_loss(self, logits: Tuple[torch.Tensor], **kwargs):
+    def logits_to_loss(self, logits: Tuple[torch.Tensor, torch.Tensor], **kwargs):
         """
         Computes the loss (Default: NLLLoss) by applying a similarity function (Default: dot product) to the input
         tuple of (query_vectors, context_vectors) and afterwards applying the loss function on similarity scores.
@@ -1678,7 +1678,7 @@ class TextSimilarityHead(PredictionHead):
         loss = self.loss_fct(softmax_scores, targets)
         return loss
 
-    def logits_to_preds(self, logits: Tuple[torch.Tensor], **kwargs):
+    def logits_to_preds(self, logits: Tuple[torch.Tensor, torch.Tensor], **kwargs):
         """
         Returns predicted ranks(similarity) of passages/context for each query
 
@@ -1705,5 +1705,5 @@ class TextSimilarityHead(PredictionHead):
             labels[i, indx.item()] = 1
         return labels
 
-    def formatted_preds(self, logits: Tuple[torch.Tensor], **kwargs):
+    def formatted_preds(self, logits: Tuple[torch.Tensor, torch.Tensor], **kwargs):
         raise NotImplementedError("formatted_preds is not supported in TextSimilarityHead yet!")

--- a/farm/train.py
+++ b/farm/train.py
@@ -13,6 +13,7 @@ from farm.eval import Evaluator
 from farm.data_handler.data_silo import DataSilo
 from farm.visual.ascii.images import GROWING_TREE
 from farm.modeling.adaptive_model import AdaptiveModel
+from farm.modeling.biadaptive_model import BiAdaptiveModel
 from farm.modeling.optimization import get_scheduler
 
 try:
@@ -248,6 +249,7 @@ class Trainer:
         # connect the prediction heads with the right output from processor
         self.model.connect_heads_with_processor(self.data_silo.processor.tasks, require_labels=True)
         # Check that the tokenizer fits the language model
+        #TODO: make this compliant for DP / DDP where the model class is wrapped
         if self.model._get_name() == 'BiAdaptiveModel':
             self.model.verify_vocab_size(vocab_size1=len(self.data_silo.processor.tokenizer),
                                          vocab_size2=len(self.data_silo.processor.passage_tokenizer))


### PR DESCRIPTION
- Move calc. of similarity scores from forward() to _embeddings_to_scores()
- forward() now just passes the query and passage embedding
- logits_to_loss() converts embeddings => similarity scores => loss

This will simplify later usage of DDP where we need to gather all embeddings for in-batch negative loss 