### PR TITLE
Add MultiGPU support for DPR Training via DDP

### DIFF
--- a/examples/dpr_encoder.py
+++ b/examples/dpr_encoder.py
@@ -41,8 +41,9 @@ def dense_passage_retrieval():
     ########## Settings
     ##########################
     set_all_seeds(seed=42)
-    batch_size = 2
+    batch_size = 4
     n_epochs = 3
+    distributed = False # enable for multi GPU training via DDP
     evaluate_every = 1000
     question_lang_model = "facebook/dpr-question_encoder-single-nq-base"
     passage_lang_model = "facebook/dpr-ctx_encoder-single-nq-base"
@@ -54,8 +55,7 @@ def dense_passage_retrieval():
     train_filename = "nq-train.json"
     dev_filename = "nq-dev.json"
     test_filename = "nq-dev.json"
-    max_samples = 80 #load a smaller dataset (e.g. for debugging)
-    distributed = True
+    max_samples = None # load a smaller dataset (e.g. for debugging)
 
     # For multi GPU Training via DDP we need to get the local rank
     args = parse_arguments()
@@ -78,7 +78,7 @@ def dense_passage_retrieval():
                              max_seq_len_passage=256,
                              label_list=label_list,
                              metric=metric,
-                             data_dir="../../DPR/data/retriever",
+                             data_dir="../data/retriever",
                              train_filename=train_filename,
                              dev_filename=dev_filename,
                              test_filename=test_filename,
@@ -88,7 +88,7 @@ def dense_passage_retrieval():
 
     # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
     # NOTE: In FARM, the dev set metrics differ from test set metrics in that they are calculated on a token level instead of a word level
-    data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False)
+    data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=distributed)
 
 
     # 4. Create an BiAdaptiveModel+

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -55,7 +55,8 @@ class DataSilo:
         :type batch_size: int
         :param eval_batch_size: The size of batch that should be returned by the DataLoaders for the dev and test set.
         :type eval_batch_size: int
-        :param distributed: Set to True if the program is running in a distributed setting.
+        :param distributed: Set to True if you are running in a distributed evn, e.g. using DistributedDataParallel.
+                            The DataSilo will init the DataLoader with a DistributedSampler() to distribute batches.
         :type distributed: bool
         :param automatic_loading: Set to False, if you don't want to automatically load data at initialization.
         :type automatic_loading: bool

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -240,7 +240,7 @@ def text_similarity_avg_ranks(preds, labels):
 
     :param preds: list of numpy arrays of dimension n1 x n2 containing n2 predicted ranks for n1 sequences/queries
     :type preds: List of numpy array containing similarity scores for each sequence in batch
-    :param labels: list of arrays of dimension n1 x n2 where each array contains n2 labels(0/1) dindicating whether the sequence/passage is a positive(1) passage or hard_negative(0) passage
+    :param labels: list of arrays of dimension n1 x n2 where each array contains n2 labels(0/1) indicating whether the sequence/passage is a positive(1) passage or hard_negative(0) passage
     :type labels: List of list containing values(0/1)
 
     :return: average predicted ranks of positive sequence/passage for each sample/query

--- a/farm/modeling/biadaptive_model.py
+++ b/farm/modeling/biadaptive_model.py
@@ -353,7 +353,9 @@ class BiAdaptiveModel(nn.Module, BaseBiAdaptiveModel):
         :return: all logits as torch.tensor or multiple tensors.
         """
 
-        # Run forward pass of language model
+        logger.info(f"Rank: {torch.distributed.get_rank()}, before LM forward")
+
+        # Run forward pass of both language models
         pooled_output = self.forward_lm(**kwargs)
 
         # Run forward pass of (multiple) prediction heads using the output from above

--- a/farm/modeling/biadaptive_model.py
+++ b/farm/modeling/biadaptive_model.py
@@ -353,8 +353,6 @@ class BiAdaptiveModel(nn.Module, BaseBiAdaptiveModel):
         :return: all logits as torch.tensor or multiple tensors.
         """
 
-        logger.info(f"Rank: {torch.distributed.get_rank()}, before LM forward")
-
         # Run forward pass of both language models
         pooled_output = self.forward_lm(**kwargs)
 

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1716,7 +1716,9 @@ class TextSimilarityHead(PredictionHead):
         """
         label_ids = kwargs.get(self.label_tensor_name)
         labels = torch.zeros(label_ids.size(0), label_ids.numel())
-        positive_indices = (label_ids.view(-1) == 1).nonzero()
+        
+        positive_indices = torch.nonzero(label_ids.view(-1) == 1, as_tuple=False)
+
         for i, indx in enumerate(positive_indices):
             labels[i, indx.item()] = 1
         return labels

--- a/farm/train.py
+++ b/farm/train.py
@@ -249,7 +249,7 @@ class Trainer:
         # connect the prediction heads with the right output from processor
         self.model.connect_heads_with_processor(self.data_silo.processor.tasks, require_labels=True)
         # Check that the tokenizer(s) fits the language model(s)
-        if hasattr(model, "language_model2"):
+        if hasattr(self.model, "language_model2"):
             self.model.verify_vocab_size(vocab_size1=len(self.data_silo.processor.tokenizer),
                                          vocab_size2=len(self.data_silo.processor.passage_tokenizer))
         else:

--- a/farm/train.py
+++ b/farm/train.py
@@ -295,9 +295,7 @@ class Trainer:
 
                 # Move batch of samples to device
                 batch = {key: batch[key].to(self.device) for key in batch}
-                logger.info(f"Rank: {torch.distributed.get_rank()}, self.device = {self.device}")
                 # Forward & backward pass through model
-                logger.info(f"Rank: {torch.distributed.get_rank()}, before train => forward()")
                 logits = self.model.forward(**batch)
                 per_sample_loss = self.model.logits_to_loss(logits=logits, global_step=self.global_step, **batch)
                 loss = self.backward_propagate(per_sample_loss, step)

--- a/farm/train.py
+++ b/farm/train.py
@@ -250,11 +250,11 @@ class Trainer:
         self.model.connect_heads_with_processor(self.data_silo.processor.tasks, require_labels=True)
         # Check that the tokenizer fits the language model
         #TODO: make this compliant for DP / DDP where the model class is wrapped
-        if self.model._get_name() == 'BiAdaptiveModel':
-            self.model.verify_vocab_size(vocab_size1=len(self.data_silo.processor.tokenizer),
-                                         vocab_size2=len(self.data_silo.processor.passage_tokenizer))
-        else:
-            self.model.verify_vocab_size(vocab_size=len(self.data_silo.processor.tokenizer))
+        # if self.model._get_name() == 'BiAdaptiveModel':
+        #     self.model.verify_vocab_size(vocab_size1=len(self.data_silo.processor.tokenizer),
+        #                                  vocab_size2=len(self.data_silo.processor.passage_tokenizer))
+        # else:
+        #     self.model.verify_vocab_size(vocab_size=len(self.data_silo.processor.tokenizer))
         self.model.train()
 
         do_stopping = False
@@ -295,8 +295,9 @@ class Trainer:
 
                 # Move batch of samples to device
                 batch = {key: batch[key].to(self.device) for key in batch}
-
+                logger.info(f"Rank: {torch.distributed.get_rank()}, self.device = {self.device}")
                 # Forward & backward pass through model
+                logger.info(f"Rank: {torch.distributed.get_rank()}, before train => forward()")
                 logits = self.model.forward(**batch)
                 per_sample_loss = self.model.logits_to_loss(logits=logits, global_step=self.global_step, **batch)
                 loss = self.backward_propagate(per_sample_loss, step)

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -6,6 +6,7 @@ import os
 import signal
 import numpy as np
 import torch
+import torch.distributed as dist
 from requests.exceptions import ConnectionError
 from torch import multiprocessing as mp
 import mlflow
@@ -13,7 +14,7 @@ from copy import deepcopy
 import pandas as pd
 from tqdm import tqdm
 import time
-
+import pickle
 
 from farm.visual.ascii.images import WELCOME_BARN, WORKER_M, WORKER_F, WORKER_X
 
@@ -475,3 +476,74 @@ class Benchmarker:
             return start.elapsed_time(end) / 1000
         else:
             return end - start
+
+
+# DDP utils
+
+def all_reduce(tensor, group=None):
+    if group is None:
+        group = dist.group.WORLD
+    return dist.all_reduce(tensor, group=group)
+
+
+def all_gather_list(data, group=None, max_size=16384):
+    """Gathers arbitrary data from all nodes into a list.
+    Similar to :func:`~torch.distributed.all_gather` but for arbitrary Python
+    data. Note that *data* must be picklable.
+    Args:
+        data (Any): data from the local worker to be gathered on other workers
+        group (optional): group of the collective
+    """
+    SIZE_STORAGE_BYTES = 4  # int32 to encode the payload size
+
+    enc = pickle.dumps(data)
+    enc_size = len(enc)
+
+    if enc_size + SIZE_STORAGE_BYTES > max_size:
+        raise ValueError(
+            'encoded data exceeds max_size, this can be fixed by increasing buffer size: {}'.format(enc_size))
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    buffer_size = max_size * world_size
+
+    if not hasattr(all_gather_list, '_buffer') or \
+            all_gather_list._buffer.numel() < buffer_size:
+        all_gather_list._buffer = torch.cuda.ByteTensor(buffer_size)
+        all_gather_list._cpu_buffer = torch.ByteTensor(max_size).pin_memory()
+
+    buffer = all_gather_list._buffer
+    buffer.zero_()
+    cpu_buffer = all_gather_list._cpu_buffer
+
+    assert enc_size < 256 ** SIZE_STORAGE_BYTES, 'Encoded object size should be less than {} bytes'.format(
+        256 ** SIZE_STORAGE_BYTES)
+
+    size_bytes = enc_size.to_bytes(SIZE_STORAGE_BYTES, byteorder='big')
+
+    cpu_buffer[0:SIZE_STORAGE_BYTES] = torch.ByteTensor(list(size_bytes))
+    cpu_buffer[SIZE_STORAGE_BYTES: enc_size + SIZE_STORAGE_BYTES] = torch.ByteTensor(list(enc))
+
+    start = rank * max_size
+    size = enc_size + SIZE_STORAGE_BYTES
+    buffer[start: start + size].copy_(cpu_buffer[:size])
+
+    all_reduce(buffer, group=group)
+
+    try:
+        result = []
+        for i in range(world_size):
+            out_buffer = buffer[i * max_size: (i + 1) * max_size]
+            size = int.from_bytes(out_buffer[0:SIZE_STORAGE_BYTES], byteorder='big')
+            if size > 0:
+                result.append(pickle.loads(bytes(out_buffer[SIZE_STORAGE_BYTES: size + SIZE_STORAGE_BYTES].tolist())))
+        return result
+    except pickle.UnpicklingError:
+        raise Exception(
+            'Unable to unpickle data from other workers. all_gather_list requires all '
+            'workers to enter the function together, so this error usually indicates '
+            'that the workers have fallen out of sync somehow. Workers can fall out of '
+            'sync if one of them runs out of memory, or if there are other conditions '
+            'in your training script that can cause one worker to finish an epoch '
+            'while other workers are still iterating over their portions of the data.'
+        )


### PR DESCRIPTION
In order to enable larger batch sizes for DPR training, we need multi GPU support. 
Let's use DistributedDataParallel as it's the more performing and scalable option ...

- [x] gather tensors for loss with in-batch negatives
- [x] verify eval is only running on rank 0 
- [x] adjust vocab size check for DDP
- [x] verify distribution of dataset into batches
- [x] infer/pass distributed_world_size in prediction head
- [x] fix nonzero() deprecation warning

Future work
- [ ] refactor `all_gather_list` to torch's standard `all_gather()`