### PR TITLE
Remove empty string span answers

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1245,10 +1245,15 @@ class SquadProcessor(QAProcessor):
 
         for index, document in zip(indices, dicts_tokenized):
             for q_idx, raw in enumerate(document):
+                # TODO: These checks dont exist in NQProcessor
                 # ignore samples with empty context
                 if raw["document_text"] == "":
                     logger.warning("Ignoring sample with empty context.")
                     continue
+
+                # Removes answers where text = "". True no_answers should have raw["answers"] = []
+                raw["answers"] = [a for a in raw["answers"] if a["text"]]
+
                 # check if answer string can be found in context
                 for answer in raw["answers"]:
                     if answer["text"] not in raw["document_text"]:


### PR DESCRIPTION
If the input raw_dict["answers"] contains an answer where text="" we should remove it. Proper no_answer format is to have raw_dict["answers"]=[].

Addresses #611
