### PR TITLE
Remove quadratic loop in _init_samples_in_baskets for efficiency

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -335,8 +335,8 @@ class Processor(ABC):
         raise NotImplementedError()
 
     def _init_samples_in_baskets(self):
+        all_dicts = [b.raw for b in self.baskets]
         for basket in self.baskets:
-            all_dicts = [b.raw for b in self.baskets]
             try:
                 basket.samples = self._dict_to_samples(dictionary=basket.raw, all_dicts=all_dicts)
                 for num, sample in enumerate(basket.samples):


### PR DESCRIPTION
There is a loop within a loop in Processor._init_samples_in_baskets(self) that causes computation to scale quadratically with the number of samples. This should resolve speed issues mentioned [here](https://github.com/deepset-ai/haystack/issues/602).