### PR TITLE
Support Model Hub's model versioning

### DIFF
--- a/farm/conversion/transformers.py
+++ b/farm/conversion/transformers.py
@@ -62,7 +62,7 @@ class Converter:
         return converted_models
 
     @staticmethod
-    def convert_from_transformers(model_name_or_path, device, task_type=None, processor=None):
+    def convert_from_transformers(model_name_or_path, device, revision=None, task_type=None, processor=None):
         """
         Load a (downstream) model from huggingface's transformers format. Use cases:
          - continue training in FARM (e.g. take a squad QA model and fine-tune on your own data)
@@ -76,6 +76,8 @@ class Converter:
 
                                               See https://huggingface.co/models for full list
         :param device: "cpu" or "cuda"
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
         :param task_type: One of :
                           - 'question_answering'
                           - 'text_classification'
@@ -86,7 +88,7 @@ class Converter:
         :return: AdaptiveModel
         """
 
-        lm = LanguageModel.load(model_name_or_path)
+        lm = LanguageModel.load(model_name_or_path, revision=revision)
         if task_type is None:
             # Infer task type from config
             architecture = lm.model.config.architectures[0]
@@ -106,12 +108,12 @@ class Converter:
                              "('lm', 'question_answering', 'regression', 'text_classification', 'ner' or 'embeddings')")
 
         if task_type == "lm":
-            ph = BertLMHead.load(model_name_or_path)
+            ph = BertLMHead.load(model_name_or_path, revision=revision)
             adaptive_model = am.AdaptiveModel(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
                                               lm_output_types="per_token", device=device)
 
         elif task_type == "question_answering":
-            ph = QuestionAnsweringHead.load(model_name_or_path)
+            ph = QuestionAnsweringHead.load(model_name_or_path, revision=revision)
             adaptive_model = am.AdaptiveModel(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
                                               lm_output_types="per_token", device=device)
 
@@ -132,12 +134,12 @@ class Converter:
                 logger.error(
                     "Conversion for Text Classification with Roberta or XLMRoberta not possible at the moment.")
                 raise NotImplementedError
-            ph = TextClassificationHead.load(model_name_or_path)
+            ph = TextClassificationHead.load(model_name_or_path, revision=revision)
             adaptive_model = am.AdaptiveModel(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
                                               lm_output_types="per_sequence", device=device)
 
         elif task_type == "ner":
-            ph = TokenClassificationHead.load(model_name_or_path)
+            ph = TokenClassificationHead.load(model_name_or_path, revision=revision)
             adaptive_model = am.AdaptiveModel(language_model=lm, prediction_heads=[ph], embeds_dropout_prob=0.1,
                                               lm_output_types="per_token", device=device)
 

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -224,12 +224,13 @@ class Processor(ABC):
 
     @classmethod
     def convert_from_transformers(cls, tokenizer_name_or_path, task_type, max_seq_len, doc_stride,
-                                  tokenizer_class=None, tokenizer_args=None, use_fast=None):
-        config = AutoConfig.from_pretrained(tokenizer_name_or_path)
+                                  revision=None, tokenizer_class=None, tokenizer_args=None, use_fast=None):
+        config = AutoConfig.from_pretrained(tokenizer_name_or_path, revision=revision)
         tokenizer_args = tokenizer_args or {}
         tokenizer = Tokenizer.load(tokenizer_name_or_path,
                                    tokenizer_class=tokenizer_class,
                                    use_fast=use_fast,
+                                   revision=revision,
                                    **tokenizer_args,
                                    )
 

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -152,6 +152,7 @@ class Inferencer:
     def load(
         cls,
         model_name_or_path,
+        revision=None,
         batch_size=4,
         gpu=False,
         task_type=None,
@@ -169,7 +170,6 @@ class Inferencer:
         tokenizer_args=None,
         dummy_ph=False,
         benchmarking=False,
-
     ):
         """
         Load an Inferencer incl. all relevant components (model, tokenizer, processor ...) either by
@@ -179,6 +179,8 @@ class Inferencer:
 
         :param model_name_or_path: Local directory or public name of the model to load.
         :type model_name_or_path: str
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
         :param batch_size: Number of samples computed once per batch
         :type batch_size: int
         :param gpu: If GPU shall be used
@@ -261,9 +263,18 @@ class Inferencer:
                                  "Valid options for arg `task_type`:"
                                  "'question_answering', 'embeddings', 'text_classification', 'ner'")
 
-            model = AdaptiveModel.convert_from_transformers(model_name_or_path, device, task_type)
-            processor = Processor.convert_from_transformers(model_name_or_path, task_type, max_seq_len, doc_stride,
-                                                            tokenizer_class, tokenizer_args, use_fast)
+            model = AdaptiveModel.convert_from_transformers(model_name_or_path,
+                                                            revision=revision,
+                                                            device=device,
+                                                            task_type=task_type)
+            processor = Processor.convert_from_transformers(model_name_or_path,
+                                                            revision=revision,
+                                                            task_type=task_type,
+                                                            max_seq_len=max_seq_len,
+                                                            doc_stride=doc_stride,
+                                                            tokenizer_class=tokenizer_class,
+                                                            tokenizer_args=tokenizer_args,
+                                                            use_fast=use_fast)
 
         if not isinstance(model,ONNXAdaptiveModel):
             model, _ = optimize_model(model=model, device=device, local_rank=-1, optimizer=None)

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -511,7 +511,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         return conv.Converter.convert_to_transformers(self)
 
     @classmethod
-    def convert_from_transformers(cls, model_name_or_path, device, task_type=None, processor=None):
+    def convert_from_transformers(cls, model_name_or_path, device, revision=None, task_type=None, processor=None):
         """
         Load a (downstream) model from huggingface's transformers format. Use cases:
          - continue training in FARM (e.g. take a squad QA model and fine-tune on your own data)
@@ -524,6 +524,8 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
                                               - deepset/bert-large-uncased-whole-word-masking-squad2
 
                                               See https://huggingface.co/models for full list
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
         :param device: "cpu" or "cuda"
         :param task_type: One of :
                           - 'question_answering'
@@ -534,7 +536,11 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         :type processor: Processor
         :return: AdaptiveModel
         """
-        return conv.Converter.convert_from_transformers(model_name_or_path, device, task_type, processor)
+        return conv.Converter.convert_from_transformers(model_name_or_path,
+                                                        revision=revision,
+                                                        device=device,
+                                                        task_type=task_type,
+                                                        processor=processor)
 
 
     @classmethod

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -81,7 +81,7 @@ class LanguageModel(nn.Module):
         return model.from_scratch(vocab_size)
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, n_added_tokens=0, language_model_class=None, **kwargs):
+    def load(cls, pretrained_model_name_or_path, revision=None, n_added_tokens=0, language_model_class=None, **kwargs):
         """
         Load a pretrained language model either by
 
@@ -121,10 +121,13 @@ class LanguageModel(nn.Module):
 
         :param pretrained_model_name_or_path: The path of the saved pretrained model or its name.
         :type pretrained_model_name_or_path: str
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
         :param language_model_class: (Optional) Name of the language model class to load (e.g. `Bert`)
         :type language_model_class: str
 
         """
+        kwargs["revision"] = revision
         logger.info("")
         logger.info("LOADING MODEL")
         logger.info("=============")

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -575,7 +575,7 @@ class TokenClassificationHead(PredictionHead):
         self.generate_config()
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path):
+    def load(cls, pretrained_model_name_or_path, revision=None):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -600,7 +600,7 @@ class TokenClassificationHead(PredictionHead):
         else:
             # b) transformers style
             # load all weights from model
-            full_model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name_or_path)
+            full_model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name_or_path, revision=revision)
             # init empty head
             head = cls(layer_dims=[full_model.config.hidden_size, len(full_model.config.label2id)])
             # transfer weights for head from full model

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -310,7 +310,7 @@ class TextClassificationHead(PredictionHead):
         self.generate_config()
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path):
+    def load(cls, pretrained_model_name_or_path, revision=None):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -324,6 +324,8 @@ class TextClassificationHead(PredictionHead):
                                               - deepset/bert-base-german-cased-hatespeech-GermEval18Coarse
 
                                               See https://huggingface.co/models for full list
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
 
         """
 
@@ -335,7 +337,7 @@ class TextClassificationHead(PredictionHead):
         else:
             # b) transformers style
             # load all weights from model
-            full_model = AutoModelForSequenceClassification.from_pretrained(pretrained_model_name_or_path)
+            full_model = AutoModelForSequenceClassification.from_pretrained(pretrained_model_name_or_path, revision=revision)
             # init empty head
             head = cls(layer_dims=[full_model.config.hidden_size, len(full_model.config.id2label)])
             # transfer weights for head from full model
@@ -765,7 +767,7 @@ class BertLMHead(PredictionHead):
         self.bias = nn.Parameter(torch.zeros(vocab_size))
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, n_added_tokens=0):
+    def load(cls, pretrained_model_name_or_path, revision=None, n_added_tokens=0):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -779,6 +781,8 @@ class BertLMHead(PredictionHead):
                                               - bert-base-cased
 
                                               See https://huggingface.co/models for full list
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
 
         """
 
@@ -795,7 +799,7 @@ class BertLMHead(PredictionHead):
             # b) pytorch-transformers style
             # load weights from bert model
             # (we might change this later to load directly from a state_dict to generalize for other language models)
-            bert_with_lm = BertForPreTraining.from_pretrained(pretrained_model_name_or_path)
+            bert_with_lm = BertForPreTraining.from_pretrained(pretrained_model_name_or_path, revision=revision)
 
             # init empty head
             vocab_size = bert_with_lm.config.vocab_size + n_added_tokens
@@ -982,7 +986,7 @@ class QuestionAnsweringHead(PredictionHead):
 
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path):
+    def load(cls, pretrained_model_name_or_path, revision=None):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -997,6 +1001,8 @@ class QuestionAnsweringHead(PredictionHead):
                                               - bert-large-uncased-whole-word-masking-finetuned-squad
 
                                               See https://huggingface.co/models for full list
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
 
         """
 
@@ -1008,7 +1014,7 @@ class QuestionAnsweringHead(PredictionHead):
         else:
             # b) transformers style
             # load all weights from model
-            full_qa_model = AutoModelForQuestionAnswering.from_pretrained(pretrained_model_name_or_path)
+            full_qa_model = AutoModelForQuestionAnswering.from_pretrained(pretrained_model_name_or_path, revision=revision)
             # init empty head
             head = cls(layer_dims=[full_qa_model.config.hidden_size, 2], task_name="question_answering")
             # transfer weights for head from full model

--- a/farm/modeling/tokenization.py
+++ b/farm/modeling/tokenization.py
@@ -51,13 +51,15 @@ class Tokenizer:
     """
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, tokenizer_class=None, use_fast=False, **kwargs):
+    def load(cls, pretrained_model_name_or_path, revision=None, tokenizer_class=None, use_fast=False, **kwargs):
         """
         Enables loading of different Tokenizer classes with a uniform interface. Either infer the class from
         model config or define it manually via `tokenizer_class`.
 
         :param pretrained_model_name_or_path:  The path of the saved pretrained model or its name (e.g. `bert-base-uncased`)
         :type pretrained_model_name_or_path: str
+        :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :type revision: str
         :param tokenizer_class: (Optional) Name of the tokenizer class to load (e.g. `BertTokenizer`)
         :type tokenizer_class: str
         :param use_fast: (Optional, False by default) Indicate if FARM should try to load the fast version of the tokenizer (True) or
@@ -68,6 +70,7 @@ class Tokenizer:
         :return: Tokenizer
         """
         pretrained_model_name_or_path = str(pretrained_model_name_or_path)
+        kwargs["revision"] = revision
 
         if tokenizer_class is None:
             tokenizer_class = cls._infer_tokenizer_class(pretrained_model_name_or_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ sklearn
 seqeval==0.0.12
 mlflow==1.0.0
 # huggingface repository
-transformers==3.3.1
+transformers==3.5.1
 # accessing dictionary elements with dot notation
 dotmap==1.3.0
 # for inference-rest-apis

--- a/test/test_model_versioning.py
+++ b/test/test_model_versioning.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+from farm.infer import Inferencer
+
+def test_model_versioning(caplog=None):
+    # We want this load attempt to fail because we specify an invalid revision
+    failed_load = None
+    try:
+        failed_load = Inferencer.load("deepset/roberta-base-squad2", revision="xxx", task_type="question_answering")
+    except:
+        pass
+    assert not failed_load
+
+    model_v1 = Inferencer.load("deepset/roberta-base-squad2", revision="v1.0", task_type="question_answering")
+    model_v2 = Inferencer.load("deepset/roberta-base-squad2", revision="v2.0", task_type="question_answering")
+    model_default = Inferencer.load("deepset/roberta-base-squad2", task_type="question_answering")
+
+    weights_v1 = model_v1.model.language_model.model.encoder.layer[0].intermediate.dense.weight
+    weights_v2 = model_v2.model.language_model.model.encoder.layer[0].intermediate.dense.weight
+    weights_default = model_default.model.language_model.model.encoder.layer[0].intermediate.dense.weight
+
+    assert torch.equal(weights_default, weights_v2)
+    assert not torch.equal(weights_v1, weights_v2)

--- a/test/test_s3e_pooling.py
+++ b/test/test_s3e_pooling.py
@@ -70,7 +70,7 @@ def test_s3e_fit():
     result = inferencer.inference_from_dicts(dicts=basic_texts)
     assert result[0]["context"] == ['a', 'man', 'is', 'walking', 'on', 'the', 'street', '.']
     assert result[0]["vec"][0] - 0.00527727306941057 < 1e-6
-    assert result[0]["vec"][-2] + 0.21376857861379997 < 1e-6
+    assert result[0]["vec"][-2] + 0.06285100416478565 < 1e-6
 
 
 def test_load_extract_s3e_embeddings():
@@ -96,7 +96,7 @@ def test_load_extract_s3e_embeddings():
     result = inferencer.inference_from_dicts(dicts=basic_texts)
     assert result[0]["context"] == ['a', 'man', 'is', 'walking', 'on', 'the', 'street', '.']
     assert result[0]["vec"][0] - 0.00527727306941057 < 1e-6
-    assert result[0]["vec"][-2] + 0.21376857861379997 < 1e-6
+    assert result[0]["vec"][-2] + 0.06285100416478565 < 1e-6
 
 if __name__ == "__main__":
     test_s3e_fit()


### PR DESCRIPTION
Addresses #628. Allows for the new revision argument that defines which version of a model from HuggingFace's Model Hub to use. 

This PR adds the argument to the `load( )` functions of the following classes:
- Inferencer
- Tokenizer
- LanguageModel
- PredictionHead
- Converter

This should probably not be merged before #624 