### PR TITLE
MLFlowLogger can be disabled

### DIFF
--- a/farm/infer.py
+++ b/farm/infer.py
@@ -15,12 +15,11 @@ from farm.data_handler.utils import grouper
 from farm.data_handler.inputs import QAInput
 from farm.modeling.adaptive_model import AdaptiveModel, BaseAdaptiveModel, ONNXAdaptiveModel
 from farm.modeling.optimization import optimize_model
-from farm.utils import initialize_device_settings
+from farm.utils import initialize_device_settings, MLFlowLogger
 from farm.utils import set_all_seeds, calc_chunksize, log_ascii_workers, Benchmarker
 from farm.modeling.predictions import QAPred
 
 logger = logging.getLogger(__name__)
-
 
 class Inferencer:
     """
@@ -109,6 +108,8 @@ class Inferencer:
         :return: An instance of the Inferencer.
 
         """
+        MLFlowLogger.disable()
+
         # For benchmarking
         if dummy_ph:
             model.bypass_ph()

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -95,7 +95,7 @@ class BaseMLLogger:
     This class can be extended to implement custom logging backends like MLFlow, Tensorboard, or Sacred.
     """
 
-    disable = False
+    disable_logging = False
 
     def __init__(self, tracking_uri, **kwargs):
         self.tracking_uri = tracking_uri
@@ -147,7 +147,7 @@ class MLFlowLogger(BaseMLLogger):
     """
 
     def init_experiment(self, experiment_name, run_name=None, nested=True):
-        if not self.disable:
+        if not self.disable_logging:
             try:
                 mlflow.set_tracking_uri(self.tracking_uri)
                 mlflow.set_experiment(experiment_name)
@@ -161,7 +161,7 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def log_metrics(cls, metrics, step):
-        if not cls.disable:
+        if not cls.disable_logging:
             try:
                 mlflow.log_metrics(metrics, step=step)
             except ConnectionError:
@@ -171,7 +171,7 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def log_params(cls, params):
-        if not cls.disable:
+        if not cls.disable_logging:
             try:
                 mlflow.log_params(params)
             except ConnectionError:
@@ -181,7 +181,7 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def log_artifacts(cls, dir_path, artifact_path=None):
-        if not cls.disable:
+        if not cls.disable_logging:
             try:
                 mlflow.log_artifacts(dir_path, artifact_path)
             except ConnectionError:
@@ -191,13 +191,13 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def end_run(cls):
-        if not cls.disable:
+        if not cls.disable_logging:
             mlflow.end_run()
 
     @classmethod
     def disable(cls):
         logger.warning("ML Logging is turned off. No parameters, metrics or artifacts will be logged to MLFlow.")
-        cls.disable = True
+        cls.disable_logging = True
 
 
 class TensorBoardLogger(BaseMLLogger):

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -147,55 +147,52 @@ class MLFlowLogger(BaseMLLogger):
     """
 
     def init_experiment(self, experiment_name, run_name=None, nested=True):
-        if self.disable:
-            return
-        try:
-            mlflow.set_tracking_uri(self.tracking_uri)
-            mlflow.set_experiment(experiment_name)
-            mlflow.start_run(run_name=run_name, nested=nested)
-        except ConnectionError:
-            raise Exception(
-                f"MLFlow cannot connect to the remote server at {self.tracking_uri}.\n"
-                f"MLFlow also supports logging runs locally to files. Set the MLFlowLogger "
-                f"tracking_uri to an empty string to use that."
-            )
+        if not self.disable:
+            try:
+                mlflow.set_tracking_uri(self.tracking_uri)
+                mlflow.set_experiment(experiment_name)
+                mlflow.start_run(run_name=run_name, nested=nested)
+            except ConnectionError:
+                raise Exception(
+                    f"MLFlow cannot connect to the remote server at {self.tracking_uri}.\n"
+                    f"MLFlow also supports logging runs locally to files. Set the MLFlowLogger "
+                    f"tracking_uri to an empty string to use that."
+                )
 
     @classmethod
     def log_metrics(cls, metrics, step):
-        if cls.disable:
-            return
-        try:
-            mlflow.log_metrics(metrics, step=step)
-        except ConnectionError:
-            logger.warning(f"ConnectionError in logging metrics to MLFlow.")
-        except Exception as e:
-            logger.warning(f"Failed to log metrics: {e}")
+        if not cls.disable:
+            try:
+                mlflow.log_metrics(metrics, step=step)
+            except ConnectionError:
+                logger.warning(f"ConnectionError in logging metrics to MLFlow.")
+            except Exception as e:
+                logger.warning(f"Failed to log metrics: {e}")
 
     @classmethod
     def log_params(cls, params):
-        if cls.disable:
-            return
-        try:
-            mlflow.log_params(params)
-        except ConnectionError:
-            logger.warning("ConnectionError in logging params to MLFlow")
-        except Exception as e:
-            logger.warning(f"Failed to log params: {e}")
+        if not cls.disable:
+            try:
+                mlflow.log_params(params)
+            except ConnectionError:
+                logger.warning("ConnectionError in logging params to MLFlow")
+            except Exception as e:
+                logger.warning(f"Failed to log params: {e}")
 
     @classmethod
     def log_artifacts(cls, dir_path, artifact_path=None):
-        if cls.disable:
-            return
-        try:
-            mlflow.log_artifacts(dir_path, artifact_path)
-        except ConnectionError:
-            logger.warning(f"ConnectionError in logging artifacts to MLFlow")
-        except Exception as e:
-            logger.warning(f"Failed to log artifacts: {e}")
+        if not cls.disable:
+            try:
+                mlflow.log_artifacts(dir_path, artifact_path)
+            except ConnectionError:
+                logger.warning(f"ConnectionError in logging artifacts to MLFlow")
+            except Exception as e:
+                logger.warning(f"Failed to log artifacts: {e}")
 
     @classmethod
     def end_run(cls):
-        mlflow.end_run()
+        if not cls.disable:
+            mlflow.end_run()
 
     @classmethod
     def disable(cls):

--- a/farm/utils.py
+++ b/farm/utils.py
@@ -95,6 +95,8 @@ class BaseMLLogger:
     This class can be extended to implement custom logging backends like MLFlow, Tensorboard, or Sacred.
     """
 
+    disable = False
+
     def __init__(self, tracking_uri, **kwargs):
         self.tracking_uri = tracking_uri
         print(WELCOME_BARN)
@@ -145,6 +147,8 @@ class MLFlowLogger(BaseMLLogger):
     """
 
     def init_experiment(self, experiment_name, run_name=None, nested=True):
+        if self.disable:
+            return
         try:
             mlflow.set_tracking_uri(self.tracking_uri)
             mlflow.set_experiment(experiment_name)
@@ -158,6 +162,8 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def log_metrics(cls, metrics, step):
+        if cls.disable:
+            return
         try:
             mlflow.log_metrics(metrics, step=step)
         except ConnectionError:
@@ -167,6 +173,8 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def log_params(cls, params):
+        if cls.disable:
+            return
         try:
             mlflow.log_params(params)
         except ConnectionError:
@@ -176,6 +184,8 @@ class MLFlowLogger(BaseMLLogger):
 
     @classmethod
     def log_artifacts(cls, dir_path, artifact_path=None):
+        if cls.disable:
+            return
         try:
             mlflow.log_artifacts(dir_path, artifact_path)
         except ConnectionError:
@@ -186,6 +196,11 @@ class MLFlowLogger(BaseMLLogger):
     @classmethod
     def end_run(cls):
         mlflow.end_run()
+
+    @classmethod
+    def disable(cls):
+        logger.warning("ML Logging is turned off. No parameters, metrics or artifacts will be logged to MLFlow.")
+        cls.disable = True
 
 
 class TensorBoardLogger(BaseMLLogger):


### PR DESCRIPTION
Related to #616.

To disable MLFlow logging, you simply call `MLFLowLogger.disable()`. ML Logging is now turned off in the Inferencer by default.