### PR TITLE
Fix/missing truncation bug

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -2101,7 +2101,7 @@ class SquadProcessor(Processor):
                                 label_idxs[i][0] = -100  # TODO remove this hack also from featurization
                                 label_idxs[i][1] = -100
                                 break  # Break loop around answers, so the error message is not shown multiple times
-                            elif answer_indices != answer_text.strip():
+                            elif answer_indices.strip() != answer_text.strip():
                                 logger.warning(f"""Answer using start/end indices is '{answer_indices}' while gold label text is '{answer_text}'.\n
                                                    Example will not be converted for training/evaluation.""")
                                 error_in_answer = True

--- a/farm/modeling/tokenization.py
+++ b/farm/modeling/tokenization.py
@@ -567,7 +567,7 @@ def tokenize_batch_question_answering(pre_baskets, tokenizer, indices):
     baskets = []
     # # Tokenize texts in batch mode
     texts = [d["context"] for d in pre_baskets]
-    tokenized_docs_batch = tokenizer.batch_encode_plus(texts, return_offsets_mapping=True, return_special_tokens_mask=True, add_special_tokens=False)
+    tokenized_docs_batch = tokenizer.batch_encode_plus(texts, return_offsets_mapping=True, return_special_tokens_mask=True, add_special_tokens=False, verbose=False)
 
     # Extract relevant data
     tokenids_batch = tokenized_docs_batch["input_ids"]


### PR DESCRIPTION
The tokenizer's call of the tokenize_batch_question_answering method caused warnings of untruncated input sequences. These warnings are now ignored because the encoded sequences are processed in strides afterward and truncation is therefore not needed.

Further, an input validation step for QA data had a bug where whitespaces were not correctly handled when comparing gold label texts with texts at the start/end indices. Leading and trailing whitespaces are now ignored

#673 