### PR TITLE
Relaxed constraints on dependency versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,12 +15,12 @@ requests
 scipy>=1.3.2
 sklearn
 # Metrics or logging related
-seqeval==0.0.12
-mlflow==1.0.0
+seqeval
+mlflow<=1.13.1
 # huggingface repository
 transformers==4.1.1
 # accessing dictionary elements with dot notation
-dotmap==1.3.0
+dotmap
 # for inference-rest-apis
 Werkzeug==0.16.1
 flask


### PR DESCRIPTION
The pinned version requirements are now more relaxed to prevent users from running into dependency conflicts when using FARM as one component within larger projects.

**seqeval, dotmap**
Removed the fixed version numbers. All tests passed with the different available versions of these libraries and I checked for a selection of the examples that they run as expected. 

**mlflow**
Restricted the version to the latest available version 1.13.1 or lower. All tests passed and the logging works for the examples as expected for the different available versions of mlflow. The restriction ensures that any breaking changes in future versions of mlflow will not affect us.

**Werkzeug**
Kept the version as is because there are still compatibility issues with the more recent versions (>=1.0.0) as reported earlier: https://github.com/deepset-ai/FARM/pull/250 Some smaller code changes would be needed if we decide to upgrade. For now, the best practice seems to be pinning the version number as is, e.g.: https://github.com/jarus/flask-testing/issues/143

closes #669 
closes #647 