### PR TITLE
Re-enable test_dpr_modules also for windows.

### DIFF
--- a/test/test_dpr.py
+++ b/test/test_dpr.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import torch
 import logging
@@ -11,7 +10,7 @@ from farm.modeling.tokenization import Tokenizer
 from farm.utils import set_all_seeds, initialize_device_settings
 from farm.data_handler.dataset import convert_features_to_dataset
 
-@pytest.mark.skipif(os.name == 'nt', reason="DDP does not work on Windows")
+
 def test_dpr_modules(caplog=None):
     if caplog:
         caplog.set_level(logging.CRITICAL)


### PR DESCRIPTION
Hello this PR is related to the closes isuue #637.

@Timoeller: I tested in my CI pipeline that with pytorch version 1.7.1, and  test_dpr_modules succeed on Windows, so probably as you pointed out from version 1.7.0 DDP is supported also in windows.
So, now that FARM makes use of pytorch 1.7.* it is desiderable to re-eanble this test for all operating system.



