### PR TITLE
Calculate squad evaluation metrics overall and separately for text answers and no answers

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -2076,8 +2076,10 @@ class SquadProcessor(Processor):
                         passage_len_t = len(sample.tokenized["passage_tokens"])
 
                         # Check that start and end are contained within this passage
-                        if passage_len_t > answer_start_t >= 0 and passage_len_t > answer_end_t > 0:
-                            # Then adjust the start and end offsets by adding question and special tokens
+                        # answer_end_t is 0 if the first token is the answer
+                        # answer_end_t is passage_len_t if the last token is the answer
+                        if passage_len_t > answer_start_t >= 0 and passage_len_t >= answer_end_t >= 0:
+                            # Then adjust the start and end offsets by adding question and special token
                             label_idxs[i][0] = self.sp_toks_start + question_len_t + self.sp_toks_mid + answer_start_t
                             label_idxs[i][1] = self.sp_toks_start + question_len_t + self.sp_toks_mid + answer_end_t
                         # If the start or end of the span answer is outside the passage, treat passage as no_answer

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -203,16 +203,18 @@ def squad(preds, labels):
     overall_results = squad_base(preds, labels)
 
     preds_answer = [pred for (pred, label) in zip(preds, labels) if (-1, -1) not in label]
-    labels_answer = [label for label in labels if label != [(-1, -1)]]
+    labels_answer = [label for label in labels if (-1, -1) not in label]
     answer_results = squad_base(preds_answer, labels_answer)
 
     preds_no_answer = [pred for (pred, label) in zip(preds, labels) if (-1, -1) in label]
-    labels_no_answer = [label for label in labels if label == [(-1, -1)]]
+    labels_no_answer = [label for label in labels if (-1, -1) in label]
     no_answer_results = squad_base(preds_no_answer, labels_no_answer)
 
     return {"EM": overall_results["EM"], "f1": overall_results["f1"], "top_n_accuracy": overall_results["top_n_accuracy"],
             "EM_text_answer": answer_results["EM"], "f1_text_answer": answer_results["f1"], "top_n_accuracy_text_answer": answer_results["top_n_accuracy"],
+            "Total_text_answer": len(preds_answer),
             "EM_no_answer": no_answer_results["EM"], "f1_no_answer": no_answer_results["f1"], "top_n_accuracy_no_answer": no_answer_results["top_n_accuracy"],
+            "Total_no_answer": len(preds_no_answer)
             }
 
 def top_n_accuracy(preds, labels):

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -199,13 +199,14 @@ def squad(preds, labels):
     """
     This method calculates squad evaluation metrics a) overall, b) for questions with text answer and c) for questions with no answer
     """
+    # TODO change check for no_answer questions from using (start,end)==(-1,-1) to is_impossible flag in QAInput. This needs to be done for labels though. Not for predictions.
     overall_results = squad_base(preds, labels)
 
-    preds_answer = [pred for (pred, label) in zip(preds, labels) if label != [(-1, -1)]]
+    preds_answer = [pred for (pred, label) in zip(preds, labels) if (-1, -1) not in label]
     labels_answer = [label for label in labels if label != [(-1, -1)]]
     answer_results = squad_base(preds_answer, labels_answer)
 
-    preds_no_answer = [pred for (pred, label) in zip(preds, labels) if label == [(-1, -1)]]
+    preds_no_answer = [pred for (pred, label) in zip(preds, labels) if (-1, -1) in label]
     labels_no_answer = [label for label in labels if label == [(-1, -1)]]
     no_answer_results = squad_base(preds_no_answer, labels_no_answer)
 

--- a/farm/evaluation/metrics.py
+++ b/farm/evaluation/metrics.py
@@ -156,7 +156,7 @@ def squad_EM(preds, labels):
         curr_labels = labels[doc_idx]
         if (pred_start, pred_end) in curr_labels:
             n_correct += 1
-    return n_correct/n_docs
+    return n_correct/n_docs if n_docs else 0
 
 def squad_f1(preds, labels):
     f1_scores = []
@@ -189,11 +189,30 @@ def squad_f1_single(pred, label, pred_idx=0):
     f1 = (2 * precision * recall) / (precision + recall)
     return f1
 
-def squad(preds, labels):
+def squad_base(preds, labels):
     em = squad_EM(preds=preds, labels=labels)
     f1 = squad_f1(preds=preds, labels=labels)
     top_acc = top_n_accuracy(preds=preds, labels=labels)
     return {"EM": em, "f1": f1, "top_n_accuracy": top_acc}
+
+def squad(preds, labels):
+    """
+    This method calculates squad evaluation metrics a) overall, b) for questions with text answer and c) for questions with no answer
+    """
+    overall_results = squad_base(preds, labels)
+
+    preds_answer = [pred for (pred, label) in zip(preds, labels) if label != [(-1, -1)]]
+    labels_answer = [label for label in labels if label != [(-1, -1)]]
+    answer_results = squad_base(preds_answer, labels_answer)
+
+    preds_no_answer = [pred for (pred, label) in zip(preds, labels) if label == [(-1, -1)]]
+    labels_no_answer = [label for label in labels if label == [(-1, -1)]]
+    no_answer_results = squad_base(preds_no_answer, labels_no_answer)
+
+    return {"EM": overall_results["EM"], "f1": overall_results["f1"], "top_n_accuracy": overall_results["top_n_accuracy"],
+            "EM_text_answer": answer_results["EM"], "f1_text_answer": answer_results["f1"], "top_n_accuracy_text_answer": answer_results["top_n_accuracy"],
+            "EM_no_answer": no_answer_results["EM"], "f1_no_answer": no_answer_results["f1"], "top_n_accuracy_no_answer": no_answer_results["top_n_accuracy"],
+            }
 
 def top_n_accuracy(preds, labels):
     """

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -929,7 +929,7 @@ class QuestionAnsweringHead(PredictionHead):
                  no_ans_boost=0.0,
                  context_window_size=100,
                  n_best=5,
-                 n_best_per_sample=1,
+                 n_best_per_sample=None,
                  duplicate_filtering=-1,
                  **kwargs):
         """
@@ -967,9 +967,15 @@ class QuestionAnsweringHead(PredictionHead):
         self.no_ans_boost = no_ans_boost
         self.context_window_size = context_window_size
         self.n_best = n_best
-        self.n_best_per_sample = n_best_per_sample
+        if n_best_per_sample:
+            self.n_best_per_sample = n_best_per_sample
+        else:
+            # increasing n_best_per_sample to n_best ensures that there are n_best predictions in total
+            # otherwise this might not be the case for very short documents with only one "sample"
+            self.n_best_per_sample = n_best
         self.duplicate_filtering = duplicate_filtering
         self.generate_config()
+
 
 
     @classmethod


### PR DESCRIPTION
Squad evaluation metrics for QA are now calculated a) overall (as before), b) for questions with text answer and c) for questions with no answer.

Questions with no answer are identified by (start,end) == (-1,-1) and the calculation of the metrics is done by splitting the predictions and labels accordingly into two sets.

Also: Fixing a bug that appears when processing ground truth labels where either the first token in the text is the correct (and complete) answer or the very last token. These cases were wrongly handled as impossible_to_answer. Example IDs in dev-v2.json: '57340d124776f419006617bf', '57377ec7c3c5551400e51f09'

Limitations: The number of tokens in a passage `passage_len_t` and the index of the last token `answer_end_t` are counterintuitive. There are cases when `answer_end_t == passage_len_t`.

Closes #686 