### PR TITLE
WIP: qa model confidence as extra model on top

### DIFF
--- a/examples/question_answering_cofidence_calibration.py
+++ b/examples/question_answering_cofidence_calibration.py
@@ -1,0 +1,116 @@
+import pickle
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import precision_recall_fscore_support, classification_report
+from farm.evaluation.metrics import squad_f1_single
+from farm.infer import QAInferencer
+
+
+def _inference_f1(res):
+    f1_scores = []
+
+    for qapred in res:
+        if qapred.prediction[0].answer == "no_answer":
+            best_pred = (-1,-1)
+        else:
+            best_pred = (qapred.prediction[0].offset_answer_start, qapred.prediction[0].offset_answer_end)
+        if len(qapred.ground_truth_answer) == 0:
+            labels = [(-1,-1)]
+        else:
+            labels = []
+            for gt in qapred.ground_truth_answer:
+                labels.append((gt["answer_start"],gt["answer_start"]+len(gt["text"])))
+        best_f1 = max([_qa_f1_single(best_pred, label) for label in labels])
+        f1_scores.append(best_f1)
+    return f1_scores
+
+def _qa_f1_single(pred, label):
+    label_start, label_end = label
+    pred_start,pred_end = pred
+
+
+    if (pred_start + pred_end == 0) or (label_start + label_end == 0):
+        if pred_start == label_start:
+            return 1.0
+        else:
+            return 0.0
+    pred_span = list(range(pred_start, pred_end + 1))
+    label_span = list(range(label_start, label_end + 1))
+    n_overlap = len([x for x in pred_span if x in label_span])
+    if n_overlap == 0:
+        return 0.0
+    precision = n_overlap / len(pred_span)
+    recall = n_overlap / len(label_span)
+    f1 = (2 * precision * recall) / (precision + recall)
+    return f1
+
+def extract_preds_labels(datafile, model = "deepset/minilm-uncased-squad2"):
+    model = QAInferencer.load(
+                model_name_or_path=model,
+                task_type="question_answering",
+                batch_size=80,
+                gpu=True
+    )
+
+    res = model.inference_from_file(datafile,return_json=False)
+    return res
+
+
+def calibrate_confidence(res):
+    # extract weather gold label was text or no_answer
+    text_answer = []
+    for qapred in res:
+        if len(qapred.ground_truth_answer) == 0:
+            text_answer.append(0)
+        else:
+            text_answer.append(1)
+
+    text_answer = np.array(text_answer)
+
+    # extract features and f1 scores
+    features = []
+    f1_scores = np.array(_inference_f1(res))
+    for qapred in res:
+        feat = qapred.prediction[0].conf_scores.copy()  # conf_scores =   [start_logits[0].item(), end_logits[0].item(), score_start, score_end]
+        feat.append((feat[0]+feat[1]) > (feat[2]+feat[3]))
+        feat = np.array(feat)
+        features.append(feat)
+    features = np.array(features)
+
+    for THRESHOLD in [0.8,0.9,1]:
+        # create hit or miss labels
+        conf_labels = f1_scores >= THRESHOLD
+
+        # potentially separate answer vs no_answer TODO understand why no_answer confidence can be exactly determined
+        #features = features[text_answer == 1]
+        #conf_labels = conf_labels[text_answer == 1]
+
+        #train test split
+        X_train, X_test, y_train, y_test = train_test_split(features, conf_labels, test_size = 0.33)
+
+        # apply logistic regression
+        # Fit classifier with out-of-bag estimates
+        params = {'n_estimators': 1200, 'max_depth': 3, 'subsample': 0.5,
+                  'learning_rate': 0.01, 'min_samples_leaf': 1, 'random_state': 3}
+        clf = GradientBoostingClassifier(**params)
+        clf.fit(X_train, y_train)
+
+        # print scores
+        print(f"Statistics on f1 score bigger than: {THRESHOLD}")
+        print(f"test accuracy score {clf.score(X_test, y_test)} - majority vote accuracy: {sum(y_test)/y_test.shape[0]}")
+        preds = clf.predict(X_test)
+        print(classification_report(y_true=y_test, y_pred=preds))
+
+        print(f"Fteaure importance: {clf.feature_importances_}")
+
+if __name__ == "__main__":
+    datafile = "../data/squad20/dev-v2.0.json"
+    model = "deepset/minilm-uncased-squad2"
+    #res = extract_preds_labels(datafile=datafile, model=model)
+
+    #pickle.dump(res,open("../data/squad20/res.pkl","wb"))
+    res = pickle.load(open("../data/squad20/res.pkl","rb"))
+
+    calibrate_confidence(res)

--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -431,6 +431,8 @@ class DataSilo:
         logger.info("================")
 
         self.counts = {}
+        clipped = -1
+        ave_len = -1
 
         if self.data["train"]:
             self.counts["train"] = len(self.data["train"])
@@ -440,8 +442,7 @@ class DataSilo:
                 clipped, ave_len, seq_lens, max_seq_len = self._calc_length_stats_biencoder()
             else:
                 logger.warning(f"Could not compute length statistics because 'input_ids' or 'query_input_ids' and 'passage_input_ids' are missing.")
-                clipped = -1
-                ave_len = -1
+
         else:
             self.counts["train"] = 0
 

--- a/farm/eval.py
+++ b/farm/eval.py
@@ -10,7 +10,6 @@ from farm.utils import to_numpy
 from farm.utils import MLFlowLogger as MlLogger
 from farm.modeling.adaptive_model import AdaptiveModel
 from farm.modeling.biadaptive_model import BiAdaptiveModel
-from farm.evaluation.metrics import squad_f1_single
 from farm.visual.ascii.images import BUSH_SEP
 
 logger = logging.getLogger(__name__)
@@ -106,7 +105,7 @@ class Evaluator:
                 if temperature_change > 50:
                     logger.warning(f"temperature used for calibration of confidence scores changed by more than {temperature_change} percent")
             if hasattr(head, 'aggregate_preds'):
-                #Needed to convert NQ ids from np arrays to strings
+                # Needed to convert NQ ids from np arrays to strings
                 ids_all_str = [x.astype(str) for x in ids_all[head_num]]
                 ids_all_list = [list(x) for x in ids_all_str]
                 head_ids = ["-".join(x) for x in ids_all_list]
@@ -115,57 +114,6 @@ class Evaluator:
                                                                                 passage_start_t=passage_start_t_all[head_num],
                                                                                 ids=head_ids)
 
-                import pickle
-                #pickle.dump([preds_all,label_all],open("../data/squad20/res.pkl","wb"))
-                # temp = pickle.load(open("../data/squad20/res.pkl","rb"))
-                # preds_all, label_all = temp[0], temp[1]
-                ############# scale scores here
-                # calc f1 per pred and label
-
-                for THRESHOLD in [0.2,0.4,0.6,0.8]:
-
-
-                    def _squad_f1(preds, labels):
-                        f1_scores = []
-                        n_docs = len(preds)
-                        for i in range(n_docs):
-                            best_pred = preds[i][0]
-                            best_f1 = max([squad_f1_single(best_pred, label) for label in labels[i]])
-                            f1_scores.append(best_f1)
-                        return f1_scores
-
-
-                    conf_labels = []
-                    features = []
-                    f1_scores = np.array(_squad_f1(preds_all[head_num], label_all[head_num]))
-                    for pred in preds_all[head_num]:
-                        features.append(pred[0][0].conf_scores)
-                    conf_labels = f1_scores > THRESHOLD
-                    # apply logistic regression
-                    from sklearn.linear_model import LogisticRegression
-                    clf = LogisticRegression(random_state=0, solver="lbfgs").fit(features, conf_labels)
-                    # scale confidence
-                    confidences_correct = clf.predict_proba(features)[:,1]
-                    for pred, conf in zip(preds_all[head_num], confidences_correct):
-                        pred[0][0].confidence = conf
-                    coefs = clf.coef_
-                    #logger.info(f"Logreg coeffs are: {coefs}")
-                    # TODO implement application of logistic fucntion with coef as input params for inference without training a sklearn clf
-                    # TODO order of results is messed up, since original order is based on only start+end scores but confidence on start+end+noans
-
-
-                    from farm.evaluation.metrics import metrics_per_bin
-
-                    em_per_bin, confidence_per_bin, count_per_bin = metrics_per_bin(preds_all[head_num],label_all[head_num])
-
-                    print(f"Statistics on f1 score larger: {THRESHOLD}")
-                    print(f"Logreg coeffs are: {coefs}")
-                    print("EM per bin")
-                    print(em_per_bin)
-                    # print("conf per bin")
-                    # print(confidence_per_bin)
-                    print("count per bin")
-                    print(count_per_bin)
 
             result = {"loss": loss_all[head_num] / len(self.data_loader.dataset),
                       "task_name": head.task_name}

--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -38,6 +38,7 @@ class QACandidate:
                  n_passages_in_doc: int=None,
                  passage_id: str=None,
                  confidence: float=None,
+                 conf_scores: list = None
                  ):
         """
         :param answer_type: The category that this answer falls into e.g. "no_answer", "yes", "no" or "span"
@@ -82,6 +83,7 @@ class QACandidate:
         self.n_passages_in_doc = n_passages_in_doc
         self.passage_id = passage_id
         self.confidence = confidence
+        self.conf_scores = conf_scores
 
         # This attribute is used by Haystack to store sample metadata
         self.meta = None


### PR DESCRIPTION
Tried logistic regression - did not work well.
Using gradient boosted trees seems to be better. It is also the model choice in a [QA model calibration report](https://web.stanford.edu/class/cs224n/reports/custom/report52.pdf) and a similar [paper](https://arxiv.org/pdf/1904.04792.pdf).

Statistics on Exact match (f1 score ==1)
```
test accuracy score 0.8132176575657055 - majority vote accuracy: 0.7458535340648125
              precision    recall  f1-score   support

       False       0.67      0.52      0.59       996
        True       0.85      0.91      0.88      2923

    accuracy                           0.81      3919
   macro avg       0.76      0.72      0.73      3919
weighted avg       0.80      0.81      0.80      3919
```
Feature importance: [0.18027313 0.12740962 0.31964954 0.29183679 0.08083092]
Features are: no_answer_start_logit, no_answer_end_logit, score_start, score_end, boolen if model predicts no_answer or text answer

related to #705 