### PR TITLE
Changing QA_input format in tutorial

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -55,8 +55,8 @@ Use a `public model  <https://huggingface.co/models>`__  or your own to get pred
     nlp = Inferencer.load("deepset/bert-large-uncased-whole-word-masking-squad2", task_type="question_answering")
 
     # Run predictions
-    QA_input = [{"qas": ["Why is model conversion important?"],
-                 "context": "Model conversion lets people easily switch between frameworks."}]
+    QA_input = [{"questions": ["Why is model conversion important?"],
+                 "text": "Model conversion lets people easily switch between frameworks."}]
     result = nlp.inference_from_dicts(dicts=QA_input)
 
 3. Showcase your model (API + UI)


### PR DESCRIPTION
The tutorial on QA used squad format instead of internal FARM format, e.g.:
```
QA_input = [{"qas": ["Why is model conversion important?"], "context": "Model conversion lets people easily switch between frameworks."}]
```
instead of

```
QA_input = [ { "questions": ["Why is model conversion important?"], "text": "Model conversion lets people easily switch between frameworks." }]
```
Now, the format in the tutorial is changed to the internal FARM format.
closes #734 