### PR TITLE
Fix reference before assignment in DataSilo

### DIFF
--- a/farm/data_handler/data_silo.py
+++ b/farm/data_handler/data_silo.py
@@ -431,6 +431,8 @@ class DataSilo:
         logger.info("================")
 
         self.counts = {}
+        clipped = -1
+        ave_len = -1
 
         if self.data["train"]:
             self.counts["train"] = len(self.data["train"])


### PR DESCRIPTION
When using the DataSilo without train set (e.g. in evaluation), we get `UnboundLocalError: local variable 'ave_len' referenced before assignment` because `ave_len` and `clipped` are only defined for train sets. This PR sets these variables to a default value of `-1`if no train set is given.
