### PR TITLE
Fix cosine similarity in DPR training

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1647,7 +1647,13 @@ class TextSimilarityHead(PredictionHead):
         :return: cosine similarity score of each query with each context/passage (dimension: n1xn2)
         """
         # q_vector: n1 x D, ctx_vectors: n2 x D, result n1 x n2
-        return nn.functional.cosine_similarity(query_vectors, passage_vectors, dim=1)
+        cosine_similarities = []
+        passages_per_batch = passage_vectors.shape[0]
+        for query_vector in query_vectors:
+            query_vector_repeated = query_vector.repeat(passages_per_batch, 1)
+            current_cosine_similarities = nn.functional.cosine_similarity(query_vector_repeated, passage_vectors, dim=1)
+            cosine_similarities.append(current_cosine_similarities)
+        return torch.stack(cosine_similarities)
 
     def get_similarity_function(self):
         """

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1647,6 +1647,8 @@ class TextSimilarityHead(PredictionHead):
         :return: cosine similarity score of each query with each context/passage (dimension: n1xn2)
         """
         # q_vector: n1 x D, ctx_vectors: n2 x D, result n1 x n2
+        # n1 = batch_size = number of queries
+        # n2 = (batch_size * num_positives) + (batch_size * num_hard_negatives)
         cosine_similarities = []
         passages_per_batch = passage_vectors.shape[0]
         for query_vector in query_vectors:

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1619,9 +1619,14 @@ class TextSimilarityHead(PredictionHead):
         """
         Calculates dot product similarity scores for two 2-dimensional tensors
 
-        :param query_vectors: tensor of query embeddings from BiAdaptive model of dimension n1 x D, where n1 is the number of queries/batch size and D is embedding size
+        :param query_vectors: tensor of query embeddings from BiAdaptive model
+                        of dimension n1 x D,
+                        where n1 is the number of queries/batch size and D is embedding size
         :type query_vectors: torch.Tensor
-        :param passage_vectors: tensor of context/passage embeddings from BiAdaptive model of dimension n2 x D, where n2 is the number of queries/batch size and D is embedding size
+        :param passage_vectors: tensor of context/passage embeddings from BiAdaptive model
+                        of dimension n2 x D,
+                        where n2 is (batch_size * num_positives) + (batch_size * num_hard_negatives)
+                        and D is embedding size
         :type passage_vectors: torch.Tensor
 
         :return dot_product: similarity score of each query with each context/passage (dimension: n1xn2)
@@ -1641,14 +1646,13 @@ class TextSimilarityHead(PredictionHead):
         :type query_vectors: torch.Tensor
         :param passage_vectors: tensor of context/passage embeddings from BiAdaptive model
                           of dimension n2 x D,
-                          where n2 is the number of queries/batch size and D is embedding size
+                          where n2 is (batch_size * num_positives) + (batch_size * num_hard_negatives)
+                          and D is embedding size
         :type passage_vectors: torch.Tensor
 
         :return: cosine similarity score of each query with each context/passage (dimension: n1xn2)
         """
         # q_vector: n1 x D, ctx_vectors: n2 x D, result n1 x n2
-        # n1 = batch_size = number of queries
-        # n2 = (batch_size * num_positives) + (batch_size * num_hard_negatives)
         cosine_similarities = []
         passages_per_batch = passage_vectors.shape[0]
         for query_vector in query_vectors:


### PR DESCRIPTION
When using cosine similarity as similarity metric in DPR, we get the following error:
```
  File "/home/ubuntu/pycharm/FARM/examples/dpr_encoder.py", line 159, in <module>
    dense_passage_retrieval()
  File "/home/ubuntu/pycharm/FARM/examples/dpr_encoder.py", line 144, in dense_passage_retrieval
    trainer.train()
  File "/home/ubuntu/pycharm/FARM/farm/train.py", line 301, in train
    per_sample_loss = self.model.logits_to_loss(logits=logits, global_step=self.global_step, **batch)
  File "/home/ubuntu/pycharm/FARM/farm/modeling/biadaptive_model.py", line 323, in logits_to_loss
    all_losses = self.logits_to_loss_per_head(logits, **kwargs)
  File "/home/ubuntu/pycharm/FARM/farm/modeling/biadaptive_model.py", line 307, in logits_to_loss_per_head
    all_losses.append(head.logits_to_loss(logits=logits_for_one_head, **kwargs))
  File "/home/ubuntu/pycharm/FARM/farm/modeling/prediction_head.py", line 1758, in logits_to_loss
    softmax_scores = self._embeddings_to_scores(global_query_vectors, global_passage_vectors)
  File "/home/ubuntu/pycharm/FARM/farm/modeling/prediction_head.py", line 1691, in _embeddings_to_scores
    scores = sim_func(query_vectors, passage_vectors)
  File "/home/ubuntu/pycharm/FARM/farm/modeling/prediction_head.py", line 1650, in cosine_scores
    return nn.functional.cosine_similarity(query_vectors, passage_vectors, dim=1)
RuntimeError: The size of tensor a (4) must match the size of tensor b (8) at non-singleton dimension 0
```

This PR fixes the computation of cosine similarity between query vectors and passage vectors.