### PR TITLE
Fix conversion of BiAdaptiveModel

### DIFF
--- a/farm/modeling/biadaptive_model.py
+++ b/farm/modeling/biadaptive_model.py
@@ -464,8 +464,10 @@ class BiAdaptiveModel(nn.Module, BaseBiAdaptiveModel):
                 transformers_model2 = AutoModel.from_config(config=self.language_model2.model.config)
 
             # transfer weights for language model + prediction head
-            setattr(transformers_model1, transformers_model1.base_model_prefix, self.language_model1.model)
-            setattr(transformers_model2, transformers_model2.base_model_prefix, self.language_model2.model)
+            setattr(transformers_model1, transformers_model1.base_model_prefix,
+                    getattr(self.language_model1.model, self.language_model1.model.base_model_prefix))
+            setattr(transformers_model2, transformers_model2.base_model_prefix,
+                    getattr(self.language_model2.model, self.language_model2.model.base_model_prefix))
             logger.warning("No prediction head weights are required for DPR")
 
         else:


### PR DESCRIPTION
When converting a DPR model to transformers and then trying to load this model again, the weights cannot be correctly mapped. This PR fixes this issue.