### PR TITLE
Convert QACandidates with empty or whitespace answers to no_answers on doc level

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1423,7 +1423,7 @@ class QuestionAnsweringHead(PredictionHead):
                                                         score=qa_candidate.score,
                                                         answer_type=qa_candidate.answer_type,
                                                         offset_unit="token",
-                                                        aggregation_level="passage",
+                                                        aggregation_level="document",
                                                         passage_id=str(sample_idx),
                                                         n_passages_in_doc=n_samples,
                                                         confidence=qa_candidate.confidence)

--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -102,6 +102,7 @@ class QACandidate:
         and end indices that are stored in the object. """
         if string == "":
             self.answer = "no_answer"
+            self.aggregation_level = "document"
             if self.offset_answer_start != 0 or self.offset_answer_end != 0:
                 logger.error(f"Both start and end offsets should be 0: \n"
                              f"{self.offset_answer_start}, {self.offset_answer_end} with a no_answer. ")
@@ -189,7 +190,16 @@ class QACandidate:
         else:
             end_ch = token_offsets[end_t]
 
-        final_text = clear_text[start_ch: end_ch].strip()
+        final_text = clear_text[start_ch: end_ch]
+
+        # if the final_text is more than whitespaces we trim it otherwise return a no_answer
+        # final_text can be an empty string if start_t points to the very final token of the passage
+        # final_text can be a whitespace if there is a whitespace token in the text, e.g.,
+        # if the original text contained multiple consecutive whitespaces
+        if len(final_text.strip()) > 0:
+            final_text = final_text.strip()
+        else:
+            return "", 0, 0
         end_ch = int(start_ch + len(final_text))
 
         return final_text, start_ch, end_ch

--- a/farm/modeling/predictions.py
+++ b/farm/modeling/predictions.py
@@ -102,7 +102,6 @@ class QACandidate:
         and end indices that are stored in the object. """
         if string == "":
             self.answer = "no_answer"
-            self.aggregation_level = "document"
             if self.offset_answer_start != 0 or self.offset_answer_end != 0:
                 logger.error(f"Both start and end offsets should be 0: \n"
                              f"{self.offset_answer_start}, {self.offset_answer_end} with a no_answer. ")


### PR DESCRIPTION
There are no_answer QACandidates with non-zero start/end indices that cause errors as reported in #729 .

Here are two examples. The first examples contains multiple consecutive whitespaces "mass of _ _ will" because latex commands were removed from the original text. The second example contains a whitespace at the very end "geographer. _"

```
    QA_input = [
        {
            "questions": ["What has a magnitude of about 8.81 meters per second squared?"],
            "text": """What we now call gravity was not identified as a universal force until the work of Isaac Newton. Before Newton, the tendency for objects to fall towards the Earth was not understood to be related to the motions of celestial objects. Galileo was instrumental in describing the characteristics of falling objects by determining that the acceleration of every object in free-fall was constant and independent of the mass of the object. Today, this acceleration due to gravity towards the surface of the Earth is usually designated as  and has a magnitude of about 9.81 meters per second squared (this measurement is taken from sea level and may vary depending on location), and points toward the center of the Earth. This observation means that the force of gravity on an object at the Earth's surface is directly proportional to the object's mass. Thus an object that has a mass of  will experience a force:"""
        }]
```

```
    QA_input = [
        {
            "questions": [" When was Isiah Bowman not appointed to President Wilson\'s Inquiry?"],
            "text": """One key figure in the plans for what would come to be known as American Empire, was a geographer named Isiah Bowman. Bowman was the director of the American Geographical Society in 1914. Three years later in 1917, he was appointed to then President Woodrow Wilson's inquiry in 1917. The inquiry was the idea of President Wilson and the American delegation from the Paris Peace Conference. The point of this inquiry was to build a premise that would allow for U.S authorship of a 'new world' which was to be characterized by geographical order. As a result of his role in the inquiry, Isiah Bowman would come to be known as Wilson's geographer. """
        }]
```

This PR fixes the issue by converting all predicted answers to no_answers that consist of an empty string or contain no other symbols than whitespaces (including tabs). Further, the start/end indices are set to zero and the aggregation level is set to "document" for all no_answers.

**Limitations**
The fix prevents the question answering models from predicting answers that contain only whitespaces or tabs. 
Answers with empty string were already prevented before.

fixes #729 