### PR TITLE
Fix TextPairClassificationProcessor example by adding metric

### DIFF
--- a/examples/passage_ranking.py
+++ b/examples/passage_ranking.py
@@ -69,6 +69,7 @@ def text_pair_classification():
     #    We will be using the msmarco dev set as our final evaluation set
     processor = TextPairClassificationProcessor(tokenizer=tokenizer,
                                                 label_list=label_list,
+                                                metric="f1_macro",
                                                 train_filename=train_filename,
                                                 test_filename=None,
                                                 dev_split=0.001,


### PR DESCRIPTION
Without setting a metric, the TextPairClassificationProcessor cannot be initialized and the following message is shown:
"Initialized processor without tasks. Supply `metric` and `label_list` to the constructor for using the default task or add a custom task later via processor.add_task()" https://github.com/deepset-ai/FARM/blob/751b48f0310e11c0e4cbdb95f264e47a587d86e1/farm/data_handler/processor.py#L587

This PR sets the missing metric to f1_macro in the passage ranking example.