### PR TITLE
Added assertion for questions with token length > self.max_query_length.

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1984,6 +1984,13 @@ class SquadProcessor(Processor):
             if basket.raw["document_text"] == "":
                 logger.warning("Ignoring sample with empty context")
                 continue
+            # error: question has a token length > than self.max_query_length
+            if len(basket.raw["question_tokens"]) > self.max_query_length:
+                str_err = "Question <{}> has a token length of {} greater than self.max_query_length({}).".format(basket.raw["question_text"],
+                                                                                                                 len(basket.raw["question_tokens"]),
+                                                                                                                 self.max_query_length)
+                logger.error(str_err)
+                assert False, str_err
             ########## end checking
 
 


### PR DESCRIPTION
In Squad, I noticed that no log message or errors are thrown when questions are too long.
As my opinion this can cause wrong predictions, so better assert the right condition.
