### PR TITLE
Added value of doc_stride, max_seq_len, max_query_length in error message

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -1860,10 +1860,10 @@ class SquadProcessor(Processor):
         self.ph_output_type = "per_token_squad"
 
         assert doc_stride < (max_seq_len - max_query_length), \
-            "doc_stride is longer than max_seq_len minus space reserved for query tokens. \nThis means that there will be gaps " \
+            "doc_stride ({}) is longer than max_seq_len ({}) minus space reserved for query tokens ({}). \nThis means that there will be gaps " \
             "as the passage windows slide, causing the model to skip over parts of the document.\n" \
             "Please set a lower value for doc_stride (Suggestions: doc_stride=128, max_seq_len=384)\n " \
-            "Or decrease max_query_length"
+            "Or decrease max_query_length".format(doc_stride, max_seq_len, max_query_length)
 
         self.doc_stride = doc_stride
         self.max_query_length = max_query_length
@@ -1940,10 +1940,10 @@ class SquadProcessor(Processor):
         """
         # check again for doc stride vs max_seq_len when. Parameters can be changed for already initialized models (e.g. in haystack)
         assert self.doc_stride < (self.max_seq_len - self.max_query_length), \
-            "doc_stride is longer than max_seq_len minus space reserved for query tokens. \nThis means that there will be gaps " \
+            "doc_stride ({}) is longer than max_seq_len ({}) minus space reserved for query tokens ({}). \nThis means that there will be gaps " \
             "as the passage windows slide, causing the model to skip over parts of the document.\n" \
             "Please set a lower value for doc_stride (Suggestions: doc_stride=128, max_seq_len=384)\n " \
-            "Or decrease max_query_length"
+            "Or decrease max_query_length".format(self.doc_stride, self.max_seq_len, self.max_query_length)
 
         try:
             # Check if infer_dict is already in internal json format


### PR DESCRIPTION
I am experimenting with different max_seq_len and max_query_length and I think it is nice to have information about these value in case of negative assertion.