### PR TITLE
Allow more flexible args for model/tokenizer loading (incl. proxies etc)

### DIFF
--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -236,14 +236,15 @@ class Processor(ABC):
 
     @classmethod
     def convert_from_transformers(cls, tokenizer_name_or_path, task_type, max_seq_len, doc_stride,
-                                  revision=None, tokenizer_class=None, tokenizer_args=None, use_fast=True):
-        config = AutoConfig.from_pretrained(tokenizer_name_or_path, revision=revision)
+                                  revision=None, tokenizer_class=None, tokenizer_args=None, use_fast=True, **kwargs):
+        config = AutoConfig.from_pretrained(tokenizer_name_or_path, revision=revision, **kwargs)
         tokenizer_args = tokenizer_args or {}
         tokenizer = Tokenizer.load(tokenizer_name_or_path,
                                    tokenizer_class=tokenizer_class,
                                    use_fast=use_fast,
                                    revision=revision,
                                    **tokenizer_args,
+                                   **kwargs
                                    )
 
         # TODO infer task_type automatically from config (if possible)

--- a/farm/infer.py
+++ b/farm/infer.py
@@ -173,6 +173,7 @@ class Inferencer:
         multithreading_rust=True,
         dummy_ph=False,
         benchmarking=False,
+        **kwargs
     ):
         """
         Load an Inferencer incl. all relevant components (model, tokenizer, processor ...) either by
@@ -265,7 +266,8 @@ class Inferencer:
             model = AdaptiveModel.convert_from_transformers(model_name_or_path,
                                                             revision=revision,
                                                             device=device,
-                                                            task_type=task_type)
+                                                            task_type=task_type,
+                                                            **kwargs)
             processor = Processor.convert_from_transformers(model_name_or_path,
                                                             revision=revision,
                                                             task_type=task_type,
@@ -273,7 +275,8 @@ class Inferencer:
                                                             doc_stride=doc_stride,
                                                             tokenizer_class=tokenizer_class,
                                                             tokenizer_args=tokenizer_args,
-                                                            use_fast=use_fast)
+                                                            use_fast=use_fast,
+                                                            **kwargs)
 
         # override processor attributes loaded from config or HF with inferencer params
         processor.max_seq_len = max_seq_len

--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -516,7 +516,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         return conv.Converter.convert_to_transformers(self)
 
     @classmethod
-    def convert_from_transformers(cls, model_name_or_path, device, revision=None, task_type=None, processor=None):
+    def convert_from_transformers(cls, model_name_or_path, device, revision=None, task_type=None, processor=None, **kwargs):
         """
         Load a (downstream) model from huggingface's transformers format. Use cases:
          - continue training in FARM (e.g. take a squad QA model and fine-tune on your own data)
@@ -545,7 +545,8 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
                                                         revision=revision,
                                                         device=device,
                                                         task_type=task_type,
-                                                        processor=processor)
+                                                        processor=processor,
+                                                        **kwargs)
 
 
     @classmethod

--- a/farm/modeling/language_model.py
+++ b/farm/modeling/language_model.py
@@ -177,11 +177,11 @@ class LanguageModel(nn.Module):
         return language_model
 
     @staticmethod
-    def get_language_model_class(model_name_or_path):
+    def get_language_model_class(model_name_or_path, **kwargs):
         # it's transformers format (either from model hub or local)
         model_name_or_path = str(model_name_or_path)
 
-        config = AutoConfig.from_pretrained(model_name_or_path)
+        config = AutoConfig.from_pretrained(model_name_or_path, **kwargs)
         model_type = config.model_type
         if model_type == "xlm-roberta":
             language_model_class = "XLMRoberta"

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -312,7 +312,7 @@ class TextClassificationHead(PredictionHead):
         self.generate_config()
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, revision=None):
+    def load(cls, pretrained_model_name_or_path, revision=None, **kwargs):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -339,7 +339,7 @@ class TextClassificationHead(PredictionHead):
         else:
             # b) transformers style
             # load all weights from model
-            full_model = AutoModelForSequenceClassification.from_pretrained(pretrained_model_name_or_path, revision=revision)
+            full_model = AutoModelForSequenceClassification.from_pretrained(pretrained_model_name_or_path, revision=revision, **kwargs)
             # init empty head
             head = cls(layer_dims=[full_model.config.hidden_size, len(full_model.config.id2label)])
             # transfer weights for head from full model
@@ -581,7 +581,7 @@ class TokenClassificationHead(PredictionHead):
         self.generate_config()
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, revision=None):
+    def load(cls, pretrained_model_name_or_path, revision=None, **kwargs):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -606,7 +606,7 @@ class TokenClassificationHead(PredictionHead):
         else:
             # b) transformers style
             # load all weights from model
-            full_model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name_or_path, revision=revision)
+            full_model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name_or_path, revision=revision, **kwargs)
             # init empty head
             head = cls(layer_dims=[full_model.config.hidden_size, len(full_model.config.label2id)])
             # transfer weights for head from full model
@@ -758,7 +758,7 @@ class BertLMHead(PredictionHead):
         self.bias = nn.Parameter(torch.zeros(vocab_size))
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, revision=None, n_added_tokens=0):
+    def load(cls, pretrained_model_name_or_path, revision=None, n_added_tokens=0, **kwargs):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -790,7 +790,7 @@ class BertLMHead(PredictionHead):
             # b) pytorch-transformers style
             # load weights from bert model
             # (we might change this later to load directly from a state_dict to generalize for other language models)
-            bert_with_lm = BertForPreTraining.from_pretrained(pretrained_model_name_or_path, revision=revision)
+            bert_with_lm = BertForPreTraining.from_pretrained(pretrained_model_name_or_path, revision=revision, **kwargs)
 
             # init empty head
             vocab_size = bert_with_lm.config.vocab_size + n_added_tokens
@@ -867,7 +867,7 @@ class NextSentenceHead(TextClassificationHead):
      a pretrained language model that was saved in the Transformers style (all in one model).
     """
     @classmethod
-    def load(cls, pretrained_model_name_or_path):
+    def load(cls, pretrained_model_name_or_path, **kwargs):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -892,7 +892,7 @@ class NextSentenceHead(TextClassificationHead):
             # b) pytorch-transformers style
             # load weights from bert model
             # (we might change this later to load directly from a state_dict to generalize for other language models)
-            bert_with_lm = BertForPreTraining.from_pretrained(pretrained_model_name_or_path)
+            bert_with_lm = BertForPreTraining.from_pretrained(pretrained_model_name_or_path, **kwargs)
 
             # init empty head
             head = cls(layer_dims=[bert_with_lm.config.hidden_size, 2], loss_ignore_index=-1, task_name="nextsentence")
@@ -991,7 +991,7 @@ class QuestionAnsweringHead(PredictionHead):
 
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path, revision=None):
+    def load(cls, pretrained_model_name_or_path, revision=None, **kwargs):
         """
         Load a prediction head from a saved FARM or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -1019,7 +1019,7 @@ class QuestionAnsweringHead(PredictionHead):
         else:
             # b) transformers style
             # load all weights from model
-            full_qa_model = AutoModelForQuestionAnswering.from_pretrained(pretrained_model_name_or_path, revision=revision)
+            full_qa_model = AutoModelForQuestionAnswering.from_pretrained(pretrained_model_name_or_path, revision=revision, **kwargs)
             # init empty head
             head = cls(layer_dims=[full_qa_model.config.hidden_size, 2], task_name="question_answering")
             # transfer weights for head from full model


### PR DESCRIPTION
The first step towards implementing https://github.com/deepset-ai/haystack/issues/997

We need to pass some args like proxies or resume_download all the way down from the inferencer to HF's `from_pretrained()`