### PR TITLE
Use start and end index for confidence score

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -1081,21 +1081,28 @@ class QuestionAnsweringHead(PredictionHead):
         # To handle no_answer labels correctly (-1,-1), we set their start_position to 0. The logit at index 0 also refers to no_answer
         # TODO some language models do not have the CLS token at position 0. For these models, we need to map start_position==-1 to the index of CLS token
         start_position = [label[0][0] if label[0][0] >=0 else 0 for label in label_all]
+        end_position = [label[0][1] if label[0][1] >=0 else 0 for label in label_all]
 
         start_logits, end_logits = logits.split(1, dim=-1)
         start_logits = start_logits.squeeze(-1)
+        end_logits = end_logits.squeeze(-1)
 
         start_position = torch.tensor(start_position)
         if len(start_position.size()) > 1:
             start_position = start_position.squeeze(-1)
+        end_position = torch.tensor(end_position)
+        if len(end_position.size()) > 1:
+            end_position = end_position.squeeze(-1)
 
         ignored_index = start_logits.size(1)-1
         start_position.clamp_(0, ignored_index)
+        end_position.clamp_(0, ignored_index)
 
         nll_criterion = CrossEntropyLoss()
 
         optimizer_start = optim.LBFGS([self.temperature_for_confidence], lr=0.01, max_iter=50)
 
+        #TODO use end_position and end_logits in optimizations step too
         def eval_start():
             loss = nll_criterion(self.temperature_scale(start_logits), start_position.to(device=start_logits.device))
             loss.backward()
@@ -1172,12 +1179,12 @@ class QuestionAnsweringHead(PredictionHead):
         for sample_idx in range(batch_size):
             sample_top_n = self.get_top_candidates(sorted_candidates[sample_idx],
                                                    start_end_matrix[sample_idx],
-                                                   sample_idx, start_matrix=start_matrix[sample_idx])
+                                                   sample_idx, start_matrix=start_matrix[sample_idx], end_matrix=end_matrix[sample_idx])
             all_top_n.append(sample_top_n)
 
         return all_top_n
 
-    def get_top_candidates(self, sorted_candidates, start_end_matrix, sample_idx, start_matrix = None):
+    def get_top_candidates(self, sorted_candidates, start_end_matrix, sample_idx, start_matrix = None, end_matrix = None):
         """ Returns top candidate answers as a list of Span objects. Operates on a matrix of summed start and end logits.
         This matrix corresponds to a single sample (includes special tokens, question tokens, passage tokens).
         This method always returns a list of len n_best + 1 (it is comprised of the n_best positive answers along with the one no_answer)"""
@@ -1189,6 +1196,8 @@ class QuestionAnsweringHead(PredictionHead):
         end_idx_candidates = set()
 
         start_matrix_softmax_start = torch.softmax(start_matrix[:, 0], dim=-1)
+        #TODO select correct part of end_matrix
+        end_matrix_softmax_end = torch.softmax(end_matrix[:, 0], dim=-1)
         # Iterate over all candidates and break when we have all our n_best candidates
         for candidate_idx in range(n_candidates):
             if len(top_candidates) == self.n_best_per_sample:
@@ -1203,7 +1212,7 @@ class QuestionAnsweringHead(PredictionHead):
                 if self.duplicate_filtering > -1 and (start_idx in start_idx_candidates or end_idx in end_idx_candidates):
                     continue
                 score = start_end_matrix[start_idx, end_idx].item()
-                confidence = start_matrix_softmax_start[start_idx].item()
+                confidence = (start_matrix_softmax_start[start_idx].item() + end_matrix_softmax_end[end_idx].item())/2
                 top_candidates.append(QACandidate(offset_answer_start=start_idx,
                                                   offset_answer_end=end_idx,
                                                   score=score,
@@ -1220,7 +1229,7 @@ class QuestionAnsweringHead(PredictionHead):
                         end_idx_candidates.add(end_idx - i)
 
         no_answer_score = start_end_matrix[0, 0].item()
-        no_answer_confidence = start_matrix_softmax_start[0].item()
+        no_answer_confidence = (start_matrix_softmax_start[0].item() + end_matrix_softmax_end[0].item())/2
         top_candidates.append(QACandidate(offset_answer_start=0,
                                           offset_answer_end=0,
                                           score=no_answer_score,

--- a/test/test_question_answering.py
+++ b/test/test_question_answering.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 import pytest
 from math import isclose
+import numpy as np
 
 from farm.data_handler.processor import SquadProcessor
 from farm.modeling.adaptive_model import AdaptiveModel
@@ -219,7 +220,19 @@ def test_range_duplicate_answer_filtering(bert_base_squad2):
     assert all(distance > bert_base_squad2.model.prediction_heads[0].duplicate_filtering for distance in distances_answer_ends)
 
 
-if(__name__=="__main__"):
+def test_qa_confidence():
+    inferencer = QAInferencer.load("deepset/roberta-base-squad2", task_type="question_answering", batch_size=40, gpu=True)
+    QA_input = [
+        {
+            "questions": ["Who counted the game among the best ever made?"],
+            "text": "Twilight Princess was released to universal critical acclaim and commercial success. It received perfect scores from major publications such as 1UP.com, Computer and Video Games, Electronic Gaming Monthly, Game Informer, GamesRadar, and GameSpy. On the review aggregators GameRankings and Metacritic, Twilight Princess has average scores of 95% and 95 for the Wii version and scores of 95% and 96 for the GameCube version. GameTrailers in their review called it one of the greatest games ever created."
+        }]
+    result = inferencer.inference_from_dicts(dicts=QA_input, return_json=False)[0]
+    assert np.isclose(result.prediction[0].confidence, 0.990427553653717)
+    assert result.prediction[0].answer == "GameTrailers"
+
+
+if __name__ == "__main__":
     test_training()
     test_save_load()
     test_inference_different_inputs()
@@ -227,3 +240,4 @@ if(__name__=="__main__"):
     test_duplicate_answer_filtering()
     test_no_duplicate_answer_filtering()
     test_range_duplicate_answer_filtering()
+    test_qa_confidence()


### PR DESCRIPTION
Up to now, FARM has been using only the logit of the start index of the answer to calculate the confidence score.

With this PR, FARM now uses the mean of the confidence scores of start and end index.

closes #816