### PR TITLE
Fix issues 811 812 819 823

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,9 @@ mlruns/
 *cache*
 
 sandbox/
+
+
+# files created by example scripts
+examples/doc_classification_holdout.results.json
+examples/doc_classification_xval.results.json
+

--- a/examples/doc_classification.py
+++ b/examples/doc_classification.py
@@ -31,6 +31,9 @@ def doc_classifcation():
     evaluate_every = 100
     lang_model = "bert-base-german-cased"
     do_lower_case = False
+    dev_split = 0.1
+    dev_stratification = True
+    max_processes = 1    # 128 is default
     # or a local path:
     # lang_model = Path("../saved_models/farm-bert-base-cased")
     use_amp = None
@@ -52,6 +55,8 @@ def doc_classifcation():
                                             data_dir=Path("../data/germeval18"),
                                             label_list=label_list,
                                             metric=metric,
+                                            dev_split=dev_split,
+                                            dev_stratification=dev_stratification,
                                             label_column_name="coarse_label"
                                             )
 
@@ -59,6 +64,7 @@ def doc_classifcation():
     #    few descriptive statistics of our datasets
     data_silo = DataSilo(
         processor=processor,
+        max_processes=max_processes,
         batch_size=batch_size)
 
     # 4. Create an AdaptiveModel

--- a/examples/doc_classification_crossvalidation.py
+++ b/examples/doc_classification_crossvalidation.py
@@ -125,39 +125,6 @@ def doc_classification_crossvalidation():
         logger.info( "Total number of samples: "
                     f"{len(silo_to_use.data['train'])+len(silo_to_use.data['dev'])+len(silo_to_use.data['test'])}")
 
-        # try to access all elements of all sets
-        trainset = silo_to_use.data["train"]
-        devset = silo_to_use.data["dev"]
-        testset = silo_to_use.data["test"]
-        i = 0
-        for el in trainset:
-            i += 1
-        logger.info(f"counted train: {i}")
-        i = 0
-        for el in devset:
-            i += 1
-        logger.info(f"counted dev: {i}")
-        i = 0
-        for el in testset:
-            i += 1
-        logger.info(f"counted test: {i}")
-
-        ltrain = silo_to_use.loaders["train"]
-        logger.info(f"Length of train loader: {len(ltrain)}")
-        ldev = silo_to_use.loaders["dev"]
-        ltest = silo_to_use.loaders["test"]
-        i = 0
-        for el in ltrain:
-            i += 1
-        logger.info(f"Counted train batches: {i}")
-        i = 0
-        for el in ldev:
-            i += 1
-        logger.info(f"Counted dev batches: {i}")
-        i = 0
-        for el in ltest:
-            i += 1
-        logger.info(f"Counted test batches: {i}")
         # Create an AdaptiveModel
         # a) which consists of a pretrained language model as a basis
         language_model = LanguageModel.load(lang_model)

--- a/examples/doc_classification_crossvalidation.py
+++ b/examples/doc_classification_crossvalidation.py
@@ -1,7 +1,10 @@
 # fmt: off
 import logging
+import numbers
 import json
+import statistics
 from pathlib import Path
+from collections import defaultdict
 import torch
 
 from farm.data_handler.data_silo import DataSilo, DataSiloForCrossVal
@@ -16,6 +19,7 @@ from farm.utils import set_all_seeds, MLFlowLogger, initialize_device_settings
 from farm.eval import Evaluator
 from sklearn.metrics import matthews_corrcoef, f1_score
 from farm.evaluation.metrics import simple_accuracy, register_metrics
+
 
 def doc_classification_crossvalidation():
     ##########################
@@ -161,10 +165,9 @@ def doc_classification_crossvalidation():
 
     # for each fold, run the whole training, earlystopping to get a model, then evaluate the model
     # on the test set of each fold
-    # Remember all the results for overall metrics over all predictions of all folds and for averaging
+
+    # remember all individual evaluation results
     allresults = []
-    all_preds = []
-    all_labels = []
     bestfold = None
     bestf1_offense = -1
     save_dir = Path("saved_models/bert-german-doc-tutorial-es")
@@ -182,8 +185,6 @@ def doc_classification_crossvalidation():
         evaluator_test.log_results(result, "Test", steps=len(silo.get_data_loader("test")), num_fold=num_fold)
 
         allresults.append(result)
-        all_preds.extend(result[0].get("preds"))
-        all_labels.extend(result[0].get("labels"))
 
         # keep track of best fold
         f1_offense = result[0]["f1_offense"]
@@ -199,18 +200,36 @@ def doc_classification_crossvalidation():
     with open("doc_classification_xval.results.json", "wt") as fp:
         json.dump(allresults, fp)
 
-    # calculate overall metrics across all folds
-    xval_f1_micro = f1_score(all_labels, all_preds, labels=label_list, average="micro")
-    xval_f1_macro = f1_score(all_labels, all_preds, labels=label_list, average="macro")
-    xval_f1_offense = f1_score(all_labels, all_preds, labels=label_list, pos_label="OFFENSE")
-    xval_f1_other = f1_score(all_labels, all_preds, labels=label_list, pos_label="OTHER")
-    xval_mcc = matthews_corrcoef(all_labels, all_preds)
+    # log the best fold metric and fold
+    logger.info(f"Best fold f1_offense: {bestf1_offense} in fold {bestfold}")
 
-    logger.info("XVAL F1 MICRO:   ", xval_f1_micro)
-    logger.info("XVAL F1 MACRO:   ", xval_f1_macro)
-    logger.info("XVAL F1 OFFENSE: ", xval_f1_offense)
-    logger.info("XVAL F1 OTHER:   ", xval_f1_other)
-    logger.info("XVAL MCC:        ", xval_mcc)
+    # calculate overall metrics across all folds: we only have one head so we do this only for the first head
+    # information in each of the per-fold results
+
+    # First create a dict where for each metric, we have a list of values from each fold
+    xval_metric_lists_head0 = defaultdict(list)
+    for results in allresults:
+        head0results = results[0]
+        for name in head0results.keys():
+            if name not in ["preds", "labels"] and not name.startswith("_") and \
+                    isinstance(head0results[name], numbers.Number):
+                xval_metric_lists_head0[name].append(head0results[name])
+    # Now calculate the mean and stdev for each metric, also copy over the task name
+    xval_metric = {}
+    xval_metric["task_name"] = allresults[0][0].get("task_name", "UNKNOWN TASKNAME")
+    for name in xval_metric_lists_head0.keys():
+        values = xval_metric_lists_head0[name]
+        vmean = statistics.mean(values)
+        vstdev = statistics.stdev(values)
+        xval_metric[name+"_mean"] = vmean
+        xval_metric[name+"_stdev"] = vstdev
+
+    logger.info(f"XVAL Accuracy:   mean {xval_metric['acc_mean']} stdev {xval_metric['acc_stdev']}")
+    logger.info(f"XVAL F1 MICRO:   mean {xval_metric['f1_micro_mean']} stdev {xval_metric['f1_micro_stdev']}")
+    logger.info(f"XVAL F1 MACRO:   mean {xval_metric['f1_macro_mean']} stdev {xval_metric['f1_macro_stdev']}")
+    logger.info(f"XVAL F1 OFFENSE: mean {xval_metric['f1_offense_mean']} stdev {xval_metric['f1_offense_stdev']}")
+    logger.info(f"XVAL F1 OTHER:   mean {xval_metric['f1_other_mean']} stdev {xval_metric['f1_other_stdev']}")
+    logger.info(f"XVAL MCC:        mean {xval_metric['mcc_mean']} stdev {xval_metric['mcc_stdev']}")
 
     # -----------------------------------------------------
     # Just for illustration, use the best model from the best xval val for evaluation on
@@ -228,11 +247,12 @@ def doc_classification_crossvalidation():
     model.connect_heads_with_processor(data_silo.processor.tasks, require_labels=True)
 
     result = evaluator_origtest.eval(model)
-    logger.info("TEST F1 MICRO:   ", result[0]["f1_micro"])
-    logger.info("TEST F1 MACRO:   ", result[0]["f1_macro"])
-    logger.info("TEST F1 OFFENSE: ", result[0]["f1_offense"])
-    logger.info("TEST F1 OTHER:   ", result[0]["f1_other"])
-    logger.info("TEST MCC:        ", result[0]["mcc"])
+    logger.info(f"TEST Accuracy:   {result[0]['acc']}")
+    logger.info(f"TEST F1 MICRO:   {result[0]['f1_micro']}")
+    logger.info(f"TEST F1 MACRO:   {result[0]['f1_macro']}")
+    logger.info(f"TEST F1 OFFENSE: {result[0]['f1_offense']}")
+    logger.info(f"TEST F1 OTHER:   {result[0]['f1_other']}")
+    logger.info(f"TEST MCC:        {result[0]['mcc']}")
 
 
 if __name__ == "__main__":

--- a/examples/doc_classification_holdout.py
+++ b/examples/doc_classification_holdout.py
@@ -1,0 +1,263 @@
+# fmt: off
+import logging
+import numbers
+import json
+import statistics
+from pathlib import Path
+from collections import defaultdict
+import torch
+
+from farm.data_handler.data_silo import DataSilo, DataSiloForHoldout
+from farm.data_handler.processor import TextClassificationProcessor
+from farm.modeling.optimization import initialize_optimizer
+from farm.modeling.adaptive_model import AdaptiveModel
+from farm.modeling.language_model import LanguageModel
+from farm.modeling.prediction_head import TextClassificationHead
+from farm.modeling.tokenization import Tokenizer
+from farm.train import Trainer, EarlyStopping
+from farm.utils import set_all_seeds, MLFlowLogger, initialize_device_settings
+from farm.eval import Evaluator
+from sklearn.metrics import matthews_corrcoef, f1_score
+from farm.evaluation.metrics import simple_accuracy, register_metrics
+
+
+def doc_classification_holdout():
+    ##########################
+    ########## Logging
+    ##########################
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO)
+    # reduce verbosity from transformers library
+    logging.getLogger('transformers').setLevel(logging.WARNING)
+
+    # ml_logger = MLFlowLogger(tracking_uri="https://public-mlflow.deepset.ai/")
+    # for local logging instead:
+    ml_logger = MLFlowLogger(tracking_uri="logs")
+    # ml_logger.init_experiment(experiment_name="Public_FARM", run_name="DocClassification_ES_f1_1")
+
+    ##########################
+    ########## Settings
+    ##########################
+    holdout_splits = 5
+    holdout_train_split = 0.8
+    holdout_stratified = True
+
+    set_all_seeds(seed=42)
+    device, n_gpu = initialize_device_settings(use_cuda=True)
+    n_epochs = 20
+    batch_size = 32
+    evaluate_every = 100
+    lang_model = "bert-base-german-cased"
+    do_lower_case = False
+    use_amp = None
+
+    # 1.Create a tokenizer
+    tokenizer = Tokenizer.load(
+        pretrained_model_name_or_path=lang_model,
+        do_lower_case=do_lower_case)
+
+    # The evaluation on the dev-set can be done with one of the predefined metrics or with a
+    # metric defined as a function from (preds, labels) to a dict that contains all the actual
+    # metrics values. The function must get registered under a string name and the string name must
+    # be used.
+    def mymetrics(preds, labels):
+        acc = simple_accuracy(preds, labels).get("acc")
+        f1other = f1_score(y_true=labels, y_pred=preds, pos_label="OTHER")
+        f1offense = f1_score(y_true=labels, y_pred=preds, pos_label="OFFENSE")
+        f1macro = f1_score(y_true=labels, y_pred=preds, average="macro")
+        f1micro = f1_score(y_true=labels, y_pred=preds, average="micro")
+        mcc = matthews_corrcoef(labels, preds)
+        return {
+            "acc": acc,
+            "f1_other": f1other,
+            "f1_offense": f1offense,
+            "f1_macro": f1macro,
+            "f1_micro": f1micro,
+            "mcc": mcc
+        }
+    register_metrics('mymetrics', mymetrics)
+    metric = 'mymetrics'
+
+    # 2. Create a DataProcessor that handles all the conversion from raw text into a pytorch Dataset
+    # Here we load GermEval 2018 Data automaticaly if it is not available.
+    # GermEval 2018 only has train.tsv and test.tsv dataset - no dev.tsv
+
+    # The processor wants to know the possible labels ...
+    label_list = ["OTHER", "OFFENSE"]
+    processor = TextClassificationProcessor(tokenizer=tokenizer,
+                                            max_seq_len=64,
+                                            data_dir=Path("../data/germeval18"),
+                                            label_list=label_list,
+                                            metric=metric,
+                                            label_column_name="coarse_label"
+                                            )
+
+    # 3. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them and calculates a few descriptive statistics of our datasets
+    data_silo = DataSilo(
+        processor=processor,
+        batch_size=batch_size)
+
+    # Load one silo for each fold in our cross-validation
+    silos = DataSiloForHoldout.make(data_silo,
+                                     n_splits=holdout_splits,
+                                     train_split=holdout_train_split,
+                                     stratified=holdout_stratified)
+
+    # the following steps should be run for each of the folds of the holdout evaluation, so we put them
+    # into a function
+    def train_on_split(silo_to_use, n_eval, save_dir):
+        logger.info(f"############ Holdout: Evaluation {n_eval} of {holdout_splits} ############")
+        # Create an AdaptiveModel
+        # a) which consists of a pretrained language model as a basis
+        language_model = LanguageModel.load(lang_model)
+        # b) and a prediction head on top that is suited for our task => Text classification
+        prediction_head = TextClassificationHead(
+            class_weights=data_silo.calculate_class_weights(task_name="text_classification"),
+            num_labels=len(label_list))
+
+        model = AdaptiveModel(
+            language_model=language_model,
+            prediction_heads=[prediction_head],
+            embeds_dropout_prob=0.2,
+            lm_output_types=["per_sequence"],
+            device=device)
+
+        # Create an optimizer
+        model, optimizer, lr_schedule = initialize_optimizer(
+            model=model,
+            learning_rate=0.5e-5,
+            device=device,
+            n_batches=len(silo_to_use.loaders["train"]),
+            n_epochs=n_epochs,
+            use_amp=use_amp)
+
+        # Feed everything to the Trainer, which keeps care of growing our model into powerful plant and evaluates it from time to time
+        # Also create an EarlyStopping instance and pass it on to the trainer
+
+        # An early stopping instance can be used to save the model that performs best on the dev set
+        # according to some metric and stop training when no improvement is happening for some iterations.
+        # NOTE: Using a different save directory for each fold, allows us afterwards to use the
+        # nfolds best models in an ensemble!
+        save_dir = Path(str(save_dir) + f"-{n_eval}")
+        earlystopping = EarlyStopping(
+            metric="f1_offense", mode="max",   # use the metric from our own metrics function instead of loss
+            save_dir=save_dir,  # where to save the best model
+            patience=5    # number of evaluations to wait for improvement before terminating the training
+        )
+
+        trainer = Trainer(
+            model=model,
+            optimizer=optimizer,
+            data_silo=silo_to_use,
+            epochs=n_epochs,
+            n_gpu=n_gpu,
+            lr_schedule=lr_schedule,
+            evaluate_every=evaluate_every,
+            device=device,
+            early_stopping=earlystopping,
+            evaluator_test=False)
+
+        # train it
+        trainer.train()
+
+        return trainer.model
+
+    # for each fold, run the whole training, earlystopping to get a model, then evaluate the model
+    # on the test set of each fold
+
+    # remember all individual evaluation results
+    allresults = []
+    bestfold = None
+    bestf1_offense = -1
+    save_dir = Path("saved_models/bert-german-doc-tutorial-es")
+    for num_fold, silo in enumerate(silos):
+        model = train_on_split(silo, num_fold, save_dir)
+
+        # do eval on test set here (and not in Trainer),
+        #  so that we can easily store the actual preds and labels for a "global" eval across all folds.
+        evaluator_test = Evaluator(
+            data_loader=silo.get_data_loader("test"),
+            tasks=silo.processor.tasks,
+            device=device
+        )
+        result = evaluator_test.eval(model, return_preds_and_labels=True)
+        evaluator_test.log_results(result, "Test", steps=len(silo.get_data_loader("test")), num_fold=num_fold)
+
+        allresults.append(result)
+
+        # keep track of best fold
+        f1_offense = result[0]["f1_offense"]
+        if f1_offense > bestf1_offense:
+            bestf1_offense = f1_offense
+            bestfold = num_fold
+
+        # emtpy cache to avoid memory leak and cuda OOM across multiple folds
+        model.cpu()
+        torch.cuda.empty_cache()
+
+    # Save the per-fold results to json for a separate, more detailed analysis
+    with open("doc_classification_holdout.results.json", "wt") as fp:
+        json.dump(allresults, fp)
+
+    # log the best fold metric and fold
+    logger.info(f"Best fold f1_offense: {bestf1_offense} in fold {bestfold}")
+
+    # calculate overall metrics across all folds: we only have one head so we do this only for the first head
+    # information in each of the per-fold results
+
+    # First create a dict where for each metric, we have a list of values from each fold
+    eval_metric_lists_head0 = defaultdict(list)
+    for results in allresults:
+        head0results = results[0]
+        for name in head0results.keys():
+            if name not in ["preds", "labels"] and not name.startswith("_") and \
+                    isinstance(head0results[name], numbers.Number):
+                eval_metric_lists_head0[name].append(head0results[name])
+    # Now calculate the mean and stdev for each metric, also copy over the task name
+    eval_metric = {}
+    eval_metric["task_name"] = allresults[0][0].get("task_name", "UNKNOWN TASKNAME")
+    for name in eval_metric_lists_head0.keys():
+        values = eval_metric_lists_head0[name]
+        vmean = statistics.mean(values)
+        vstdev = statistics.stdev(values)
+        eval_metric[name+"_mean"] = vmean
+        eval_metric[name+"_stdev"] = vstdev
+
+    logger.info(f"HOLDOUT Accuracy:   mean {eval_metric['acc_mean']} stdev {eval_metric['acc_stdev']}")
+    logger.info(f"HOLDOUT F1 MICRO:   mean {eval_metric['f1_micro_mean']} stdev {eval_metric['f1_micro_stdev']}")
+    logger.info(f"HOLDOUT F1 MACRO:   mean {eval_metric['f1_macro_mean']} stdev {eval_metric['f1_macro_stdev']}")
+    logger.info(f"HOLDOUT F1 OFFENSE: mean {eval_metric['f1_offense_mean']} stdev {eval_metric['f1_offense_stdev']}")
+    logger.info(f"HOLDOUT F1 OTHER:   mean {eval_metric['f1_other_mean']} stdev {eval_metric['f1_other_stdev']}")
+    logger.info(f"HOLDOUT MCC:        mean {eval_metric['mcc_mean']} stdev {eval_metric['mcc_stdev']}")
+
+    # -----------------------------------------------------
+    # Just for illustration, use the best model from the best xval val for evaluation on
+    # the original (still unseen) test set.
+    logger.info("###### Final Eval on hold out test set using best model #####")
+    evaluator_origtest = Evaluator(
+        data_loader=data_silo.get_data_loader("test"),
+        tasks=data_silo.processor.tasks,
+        device=device
+    )
+    # restore model from the best fold
+    lm_name = model.language_model.name
+    save_dir = Path(f"saved_models/bert-german-doc-tutorial-es-{bestfold}")
+    model = AdaptiveModel.load(save_dir, device, lm_name=lm_name)
+    model.connect_heads_with_processor(data_silo.processor.tasks, require_labels=True)
+
+    result = evaluator_origtest.eval(model)
+    logger.info(f"TEST Accuracy:   {result[0]['acc']}")
+    logger.info(f"TEST F1 MICRO:   {result[0]['f1_micro']}")
+    logger.info(f"TEST F1 MACRO:   {result[0]['f1_macro']}")
+    logger.info(f"TEST F1 OFFENSE: {result[0]['f1_offense']}")
+    logger.info(f"TEST F1 OTHER:   {result[0]['f1_other']}")
+    logger.info(f"TEST MCC:        {result[0]['mcc']}")
+
+
+if __name__ == "__main__":
+    doc_classification_holdout()
+
+# fmt: on

--- a/farm/data_handler/dataset.py
+++ b/farm/data_handler/dataset.py
@@ -44,7 +44,7 @@ def convert_features_to_dataset(features):
                                    f"A non-integer value for feature '{t_name}' with a value of: "
                                    f"'{base}' will be converted to a torch tensor of dtype long.")
             except:
-                logger.warning(f"Could not determine type for feature '{t_name}'. ",
+                logger.warning(f"Could not determine type for feature '{t_name}'. "
                                "Converting now to a tensor of default type long.")
 
             # Convert all remaining python objects to torch long tensors

--- a/farm/data_handler/dataset.py
+++ b/farm/data_handler/dataset.py
@@ -1,9 +1,9 @@
+from typing import Iterable
 import numpy as np
 import numbers
 import logging
 import torch
-from torch.utils.data import TensorDataset
-from collections.abc import Iterable
+from torch.utils.data import Dataset, ConcatDataset, TensorDataset
 from farm.utils import flatten_list
 
 logger = logging.getLogger(__name__)
@@ -17,7 +17,8 @@ def convert_features_to_dataset(features):
                      names of the type of feature and the keys are the features themselves.
     :Return: a Pytorch dataset and a list of tensor names.
     """
-    # features can be an empty list in cases where down sampling occurs (e.g. Natural Questions downsamples instances of is_impossible)
+    # features can be an empty list in cases where down sampling occurs (e.g. Natural Questions
+    # downsamples instances of is_impossible)
     if len(features) == 0:
         return None, None
     tensor_names = list(features[0].keys())
@@ -43,7 +44,8 @@ def convert_features_to_dataset(features):
                                    f"A non-integer value for feature '{t_name}' with a value of: "
                                    f"'{base}' will be converted to a torch tensor of dtype long.")
             except:
-                logger.warning(f"Could not determine type for feature '{t_name}'. Converting now to a tensor of default type long.")
+                logger.warning(f"Could not determine type for feature '{t_name}'. ",
+                               "Converting now to a tensor of default type long.")
 
             # Convert all remaining python objects to torch long tensors
             cur_tensor = torch.tensor([sample[t_name] for sample in features], dtype=torch.long)
@@ -52,3 +54,29 @@ def convert_features_to_dataset(features):
 
     dataset = TensorDataset(*all_tensors)
     return dataset, tensor_names
+
+
+class ConcatTensorDataset(ConcatDataset):
+    r"""ConcatDataset of only TensorDatasets which supports getting slices.
+
+    This dataset allows the use of slices, e.g. ds[2:4] if all concatenated
+    datasets are either TensorDatasets or Subset or other ConcatTensorDataset instances
+    which eventually contain only TensorDataset instances. If no slicing is needed,
+    this class works exactly like torch.utils.data.ConcatDataset and can concatenate arbitrary
+    (not just TensorDataset) datasets.
+
+    Args:
+        datasets (sequence): List of datasets to be concatenated
+    """
+    def __init__(self, datasets: Iterable[Dataset]) -> None:
+        super(ConcatTensorDataset, self).__init__(datasets)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            rows = [super(ConcatTensorDataset, self).__getitem__(i) for i in range(self.__len__())[idx]]
+            return tuple(map(torch.stack, zip(*rows)))
+        elif isinstance(idx, (list, np.ndarray)):
+            rows = [super(ConcatTensorDataset, self).__getitem__(i) for i in idx]
+            return tuple(map(torch.stack, zip(*rows)))
+        else:
+            return super(ConcatTensorDataset, self).__getitem__(idx)

--- a/farm/data_handler/processor.py
+++ b/farm/data_handler/processor.py
@@ -506,6 +506,7 @@ class TextClassificationProcessor(Processor):
         dev_filename=None,
         test_filename="test.tsv",
         dev_split=0.1,
+        dev_stratification=False,
         delimiter="\t",
         quote_char="'",
         skiprows=None,
@@ -542,6 +543,8 @@ class TextClassificationProcessor(Processor):
         :type test_filename: str
         :param dev_split: The proportion of the train set that will sliced. Only works if dev_filename is set to None
         :type dev_split: float
+        :param dev_stratification: if True, create a class-stratified split for the dev set.
+        :type dev_stratification: bool
         :param delimiter: Separator used in the input tsv / csv file
         :type delimiter: str
         :param quote_char: Character used for quoting strings in the input tsv/ csv file
@@ -570,6 +573,7 @@ class TextClassificationProcessor(Processor):
         self.skiprows = skiprows
         self.header = header
         self.max_samples = max_samples
+        self.dev_stratification = dev_stratification
         logger.warning(f"Currently no support in Processor for returning problematic ids")
 
         super(TextClassificationProcessor, self).__init__(
@@ -794,7 +798,8 @@ class RegressionProcessor(TextClassificationProcessor):
         :type dev_filename: str or None
         :param test_filename: None
         :type test_filename: str
-        :param dev_split: The proportion of the train set that will sliced. Only works if dev_filename is set to None
+        :param dev_split: The proportion of the train set that will sliced. No devset is created if this is set to 0.0
+            Only used if dev_filename is set to None
         :type dev_split: float
         :param delimiter: Separator used in the input tsv / csv file
         :type delimiter: str

--- a/test/test_data_silo.py
+++ b/test/test_data_silo.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from farm.modeling.tokenization import Tokenizer
 from farm.data_handler.processor import TextClassificationProcessor
-from farm.data_handler.data_silo import DataSilo, DataSiloForCrossVal
+from farm.data_handler.data_silo import DataSilo, DataSiloForCrossVal, DataSiloForHoldout
 
 
 def test_data_silo_for_cross_val_nested():
@@ -62,13 +62,98 @@ def test_data_silo_for_cross_val_nested():
     assert data_loader_train_indices_1.ndim == 1
 
     # size of dev + train + test must be same on all folds
-    assert (data_loader_train_indices_0.size + \
-           data_loader_dev_indices_0.size + \
+    assert (data_loader_train_indices_0.size +
+           data_loader_dev_indices_0.size +
            data_loader_test_indices_0.size) == \
-           (data_loader_train_indices_1.size + \
-           data_loader_dev_indices_1.size + \
+           (data_loader_train_indices_1.size +
+           data_loader_dev_indices_1.size +
            data_loader_test_indices_1.size)
 
+    del tokenizer
+    del processor
+    del data_silo
+    del silos
+
+
+def test_data_silo_for_cross_val1():
+    n_splits = 5
+    lang_model = "distilbert-base-german-cased"
+    tokenizer = Tokenizer.load(pretrained_model_name_or_path=lang_model)
+    processor = TextClassificationProcessor(tokenizer=tokenizer,
+                                            max_seq_len=64,
+                                            data_dir=Path("data/germeval18"),
+                                            label_list=["OTHER", "OFFENSE"],
+                                            metric="f1_macro",
+                                            dev_split=0.2,
+                                            dev_stratification=False,
+                                            label_column_name="coarse_label"
+                                            )
+    data_silo = DataSilo(processor=processor, batch_size=32, max_processes=128)
+    silos = DataSiloForCrossVal.make(
+        data_silo,
+        sets=['train'],
+        n_splits=n_splits,
+        )
+
+    assert len(silos) == n_splits
+    for idx, silo in enumerate(silos):
+        train_ds = silo.get_data_loader("train").dataset
+        dev_ds = silo.get_data_loader("dev").dataset
+        test_ds = silo.get_data_loader("test").dataset
+        train_indices = train_ds.datasets[0].indices
+        dev_indices = dev_ds.indices
+        train_idx_set = set([i for i in train_indices])
+        dev_idx_set = set([i for i in dev_indices])
+        orig_train = train_ds.datasets[0].dataset
+        orig_train_idx = orig_train.indices
+        test_idx = test_ds.indices
+        orig_train_idx_set = set([i for i in orig_train_idx])
+        test_idx_set = set([i for i in test_idx])
+        assert len(orig_train_idx_set.intersection(test_idx_set)) == 0
+        assert len(train_idx_set.intersection(dev_idx_set)) == 0
+    del tokenizer
+    del processor
+    del data_silo
+    del silos
+
+
+def test_data_silo_for_holdout1():
+    n_splits = 5
+    lang_model = "distilbert-base-german-cased"
+    tokenizer = Tokenizer.load(pretrained_model_name_or_path=lang_model)
+    processor = TextClassificationProcessor(tokenizer=tokenizer,
+                                            max_seq_len=64,
+                                            data_dir=Path("data/germeval18"),
+                                            label_list=["OTHER", "OFFENSE"],
+                                            metric="f1_macro",
+                                            dev_split=0.2,
+                                            dev_stratification=False,
+                                            label_column_name="coarse_label"
+                                            )
+    data_silo = DataSilo(processor=processor, batch_size=32, max_processes=128)
+    silos = DataSiloForHoldout.make(
+        data_silo,
+        sets=['train'],
+        n_splits=n_splits,
+        train_split=0.8,
+        )
+
+    assert len(silos) == n_splits
+    for idx, silo in enumerate(silos):
+        train_ds = silo.get_data_loader("train").dataset
+        dev_ds = silo.get_data_loader("dev").dataset
+        test_ds = silo.get_data_loader("test").dataset
+        train_indices = train_ds.datasets[0].indices
+        dev_indices = dev_ds.indices
+        train_idx_set = set([i for i in train_indices])
+        dev_idx_set = set([i for i in dev_indices])
+        orig_train = train_ds.datasets[0].dataset
+        orig_train_idx = orig_train.indices
+        test_idx = test_ds.indices
+        orig_train_idx_set = set([i for i in orig_train_idx])
+        test_idx_set = set([i for i in test_idx])
+        assert len(orig_train_idx_set.intersection(test_idx_set)) == 0
+        assert len(train_idx_set.intersection(dev_idx_set)) == 0
     del tokenizer
     del processor
     del data_silo


### PR DESCRIPTION
This should fix the following issues:

* 811 Implement holdout evaluation in addition to cross validation
* 812 xval example code is incorrect 
* 819 Do devset stratification
* 823 Devset split does not work with max_processes=1

The following notes are important:

* dev set stratification is done if the processor has the attribute `dev_stratification` and it has a non-None value. Otherwise, the behaviour is exactly as before, for backwards compatibility and also to make sure that this does not impact any other situations with different tasks, multihead etc.
* 823 is fixed ONLY if `dev_stratification` is specified and not None: if it is False, no stratification is done, but the split is still done properly independently of the chunk size
* The devset split in the data silo for xval is now done as configured in the processor, however only for non-nested xval and non-qa task. The other code has not been implement by myself and I am not able to test the qa part and I am not even sure I understand why the nested xval is even there. This should not be a problem as the splits ARE still done, but depending on the xval stratification setting, not the parameter specified in the processor (for qa, the processor does not even have that parameter atm). 
* I did test this extensively and added tests to make absolutely sure that no unwanted overlapping of examples occurs and I also timed my test runs to see if there is any performance impact from the new ConcatTensorDataset class I implemented. 
* I will try to create a PR for the ConcatTensorDataset to the Pytorch people, if they accept it, the class could get removed from FARM eventually (and they may even improve it, who knows, there is potential for optimization). 
* I have renamed the `stratified` parameter of the DatSiloForCrossVal make factory function to `stratification` to match the parameter name `dev_stratification` in TextClassificationProcesser, where that name was chosen because the parameter is not just boolean but can also be None (for the old way of doing things) or a callable for one's own way to perform the split. 

I have not tested this with more complex multihead models - yet: i will use this myself with multihead models, so should there be issues with that I will correct them then. 