### PR TITLE
Use correct class when transforming DPR models

### DIFF
--- a/farm/modeling/biadaptive_model.py
+++ b/farm/modeling/biadaptive_model.py
@@ -454,11 +454,13 @@ class BiAdaptiveModel(nn.Module, BaseBiAdaptiveModel):
 
         if self.prediction_heads[0].model_type == "text_similarity":
             # init model
-            if "dpr" in self.language_model1.model.config.model_type:
+            if "dpr" in self.language_model1.model.config.model_type or \
+                    self.language_model1.model.config.name == "DPRQuestionEncoder":
                 transformers_model1 = DPRQuestionEncoder(config=self.language_model1.model.config)
             else:
                 transformers_model1 = AutoModel.from_config(config=self.language_model1.model.config)
-            if "dpr" in self.language_model2.model.config.model_type:
+            if "dpr" in self.language_model2.model.config.model_type or \
+                    self.language_model2.model.config.name == "DPRContextEncoder":
                 transformers_model2 = DPRContextEncoder(config=self.language_model2.model.config)
             else:
                 transformers_model2 = AutoModel.from_config(config=self.language_model2.model.config)


### PR DESCRIPTION
When trying to convert a DPR model to transformers, `DPRQuestionEncoder` is used for the context encoder model. This is due to the fact that transformer's `AutoModel` always creates a `DPRQuestionEncoder` when it is passed a `DPRConfig`. This PR ensures that we use `DPRContextEncoder` for the context encoder model.