### PR TITLE
Add switch to QA pred head for ranking by confidence scores

### DIFF
--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -964,6 +964,8 @@ class QuestionAnsweringHead(PredictionHead):
         :type duplicate_filtering: int
         :param temperature_for_confidence: The divisor that is used to scale logits to calibrate confidence scores
         :type temperature_for_confidence: float
+        :param use_confidence_scores_for_ranking: Whether to sort answers by confidence score (normalized between 0 and 1) or by standard score (unbounded)
+        :type use_confidence_scores_for_ranking: bool
         """
         super(QuestionAnsweringHead, self).__init__()
         if len(kwargs) > 0:

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -941,6 +941,7 @@ class QuestionAnsweringHead(PredictionHead):
                  n_best_per_sample=None,
                  duplicate_filtering=-1,
                  temperature_for_confidence=1.0,
+                 use_confidence_scores_for_ranking=False,
                  **kwargs):
         """
         :param layer_dims: dimensions of Feed Forward block, e.g. [768,2], for adjusting to BERT embedding. Output should be always 2
@@ -988,6 +989,7 @@ class QuestionAnsweringHead(PredictionHead):
         self.duplicate_filtering = duplicate_filtering
         self.generate_config()
         self.temperature_for_confidence = nn.Parameter(torch.ones(1) * temperature_for_confidence)
+        self.use_confidence_scores_for_ranking = use_confidence_scores_for_ranking
 
 
     @classmethod
@@ -1472,7 +1474,7 @@ class QuestionAnsweringHead(PredictionHead):
 
         # Add no answer to positive answers, sort the order and return the n_best
         n_preds = [no_answer_pred] + pos_answer_dedup
-        n_preds_sorted = sorted(n_preds, key=lambda x: x.score, reverse=True)
+        n_preds_sorted = sorted(n_preds, key=lambda x: x.confidence if self.use_confidence_scores_for_ranking else x.score, reverse=True)
         n_preds_reduced = n_preds_sorted[:self.n_best]
         return n_preds_reduced, no_ans_gap
 

--- a/farm/modeling/prediction_head.py
+++ b/farm/modeling/prediction_head.py
@@ -931,6 +931,16 @@ class FeedForwardBlock(nn.Module):
 class QuestionAnsweringHead(PredictionHead):
     """
     A question answering head predicts the start and end of the answer on token level.
+
+    In addition, it gives a score for the prediction so that multiple answers can be ranked.
+    There are three different kinds of scores available:
+    1) (standard) score: the sum of the logits of the start and end index. This score is unbounded because the logits are unbounded.
+    It is the default for ranking answers.
+    2) confidence score: also based on the logits of the start and end index but scales them to the interval 0 to 1 and incorporates no_answer.
+    It can be used for ranking by setting use_confidence_scores_for_ranking to True
+    3) calibrated confidence score: same as 2) but divides the logits by a learned temperature_for_confidence parameter
+    so that the confidence scores are closer to the model's achieved accuracy. It can be used for ranking by setting
+    use_confidence_scores_for_ranking to True and temperature_for_confidence!=1.0. See examples/question_answering_confidence.py for more details.
     """
 
     def __init__(self, layer_dims=[768,2],
@@ -964,7 +974,7 @@ class QuestionAnsweringHead(PredictionHead):
         :type duplicate_filtering: int
         :param temperature_for_confidence: The divisor that is used to scale logits to calibrate confidence scores
         :type temperature_for_confidence: float
-        :param use_confidence_scores_for_ranking: Whether to sort answers by confidence score (normalized between 0 and 1) or by standard score (unbounded)
+        :param use_confidence_scores_for_ranking: Whether to sort answers by confidence score (normalized between 0 and 1) or by standard score (unbounded)(default).
         :type use_confidence_scores_for_ranking: bool
         """
         super(QuestionAnsweringHead, self).__init__()


### PR DESCRIPTION
`QACandidates` contain `score` and `confidence` fields but only `score` was used to rank `QACandidates` so far.
This PR makes ranking `QACandidates` by score the default but also allows to set `use_confidence_scores_for_ranking` in `QAPredictionHead`, which activates ranking 
`QACandidates` by `confidence`.

I think, it's better to keep both fields, `score` and `confidence` in `QACandidates` instead of dropping one of them entirely. Thereby, we are more flexible and allow backwards compatibility.

A new test case checks that results are ranked as expected with and without setting `use_confidence_scores_for_ranking`.

closes #808 