### PR TITLE
ONNXAdaptiveModel causes NameError: name 'onnxruntime' is not defined

### DIFF
--- a/farm/modeling/adaptive_model.py
+++ b/farm/modeling/adaptive_model.py
@@ -637,6 +637,7 @@ class ONNXAdaptiveModel(BaseAdaptiveModel):
     For inference, this class is compatible with the FARM Inferencer.
     """
     def __init__(self, onnx_session, language_model_class, language, prediction_heads, device):
+        import onnxruntime
         if str(device) == "cuda" and onnxruntime.get_device() != "GPU":
             raise Exception(f"Device {device} not available for Inference. For CPU, run pip install onnxruntime and"
                             f"for GPU run pip install onnxruntime-gpu")


### PR DESCRIPTION
fixes #847